### PR TITLE
fix: make fan controls capability aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,8 +254,8 @@ integration:
   exposes actionable same-device related entities. Angle `select` entities
   must provide numeric options such as `30`, `60°`, or `90 degrees`.
 - `auto` and `standard`: the card uses standard fan actions and related
-  entities. Primary attributes that have no matching action are displayed
-  only as state and do not create a dead control.
+  entities. Primary angle attributes without a matching action remain hidden
+  and do not create dead controls or details.
 
 The card does not connect directly to Xiaomi devices and does not invent
 MIoT property or service names. If the MIoT integration exposes only primary

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Capability-aware. Four themes. Native visual editor. No telemetry.
 
 <sub>Default configuration, light and dark, nothing but the entity set.</sub>
 
-[![Open Xiaomi Fan Card in HACS](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?repository=mrwogu%2Fxiaomi-smart-fan-card)
+[![Open Xiaomi Fan Card in HACS](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=mrwogu&repository=xiaomi-smart-fan-card&category=plugin)
 
 [Install](#install) · [Themes](#four-themes-one-card) · [Layouts](#layouts-that-fit-your-dashboard) ·
 [Styling](#style-it-your-way) · [Recipes](#recipes) · [Configuration](docs/configuration.md)
@@ -230,15 +230,45 @@ styles:
 
 ## Works with what you already have
 
-| Integration      | Set `integration:` | What you get                                                                         |
-| ---------------- | ------------------ | ------------------------------------------------------------------------------------ |
-| Xiaomi Home      | `xiaomi_miio`      | Standard fan actions plus related switch, number, select, and sensor entities.       |
-| syssi/xiaomi_fan | `xiaomi_miio_fan`  | Xiaomi services for angle, vertical oscillation, nudge, timer, LED, buzzer, ionizer. |
-| Xiaomi MIOT      | `xiaomi_miot`      | Standard fan actions with related entity discovery.                                  |
-| Any HA `fan`     | `standard`         | Percentage, presets, oscillation, direction, and whatever related entities exist.    |
+| Integration      | Set `integration:` | What you get                                                                                         |
+| ---------------- | ------------------ | ---------------------------------------------------------------------------------------------------- |
+| Auto detection   | `auto`             | Standard fan actions and related entity discovery. Vendor services are never guessed.                |
+| Xiaomi Home      | `xiaomi_miio`      | Standard fan actions plus related switch, number, select, and sensor entities.                       |
+| syssi/xiaomi_fan | `xiaomi_miio_fan`  | Xiaomi services for angle, vertical oscillation, nudge, timer, LED, buzzer, child lock, and ionizer. |
+| Xiaomi MIOT      | `xiaomi_miot`      | Standard fan actions plus actionable related entities exposed by Xiaomi MIoT.                        |
+| Any HA `fan`     | `standard`         | Percentage, presets, oscillation, direction, and whatever related entities exist.                    |
 
-`auto` keeps the card on standard fan actions and only uses custom Xiaomi
-services when you select that integration explicitly.
+`auto` and `standard` use public Home Assistant fan actions. Select
+`xiaomi_miio_fan` only when its custom services are registered in Home
+Assistant. `xiaomi_miio` and `xiaomi_miot` use standard fan actions and
+related entities instead of assuming `xiaomi_miio_fan` services.
+
+### P76 through different integrations
+
+The same physical fan can expose different capabilities depending on the
+integration:
+
+- `xiaomi_miio_fan`: P76 angle, vertical oscillation, nudge, timer, LED,
+  buzzer, and child lock actions use registered `xiaomi_miio_fan.*` services.
+- `xiaomi_miot`: P76 angle and vertical controls appear only when Xiaomi MIoT
+  exposes actionable same-device related entities. Angle `select` entities
+  must provide numeric options such as `30`, `60°`, or `90 degrees`.
+- `auto` and `standard`: the card uses standard fan actions and related
+  entities. Primary attributes that have no matching action are displayed
+  only as state and do not create a dead control.
+
+The card does not connect directly to Xiaomi devices and does not invent
+MIoT property or service names. If the MIoT integration exposes only primary
+fan attributes, use `xiaomi_miio_fan` for its vendor-specific P76 controls or
+keep those controls hidden.
+
+### Capability safety
+
+Presets and generic fan features do not imply oscillation or angle support. A
+device such as the Xiaomi Smart Air Purifier 4 Pro can expose presets,
+favorite level, LED brightness, sensors, buzzer, child lock, and ionizer while
+having no horizontal or vertical controls. The card keeps those unsupported
+controls hidden.
 
 <div align="center">
   <a href="https://raw.githubusercontent.com/mrwogu/xiaomi-smart-fan-card/main/docs/media/integration-modes.webp">
@@ -359,6 +389,26 @@ controls:
   show_timer: false
 ```
 
+**Unsupported optional controls.** Use this for an air purifier or any fan
+whose integration reports presets but does not expose actionable oscillation
+or angle entities.
+
+```yaml
+type: custom:xiaomi-fan-card
+entity: fan.air_purifier_4_pro
+integration: xiaomi_miot
+controls:
+  show_horizontal_swing: false
+  show_vertical_swing: false
+  show_horizontal_angle: false
+  show_vertical_angle: false
+  show_cycle: false
+  show_nudge: false
+details:
+  show_horizontal_angle: false
+  show_vertical_angle: false
+```
+
 **One control column.** Every group stacked, for narrow dashboard columns.
 
 ```yaml
@@ -446,6 +496,14 @@ primary fan entity attributes, related device entities, and registered Home
 Assistant services. If the integration does not expose the capability, the card
 intentionally hides that control. See
 [docs/compatibility.md](docs/compatibility.md).
+
+For `xiaomi_miot`, verify that the related entity exists, belongs to the same
+device, is available, and exposes the expected domain and options. Include the
+integration name, Home Assistant and HACS versions, browser, redacted primary
+entity state and attributes, redacted related entity domains, states, and
+options, registered service names, card configuration, console error, and exact
+reproduction steps in a bug report. Never include tokens, cookies, hostnames,
+private dashboards, or full diagnostics exports.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -243,14 +243,14 @@ styles:
 Assistant. `xiaomi_miio` and `xiaomi_miot` use standard fan actions and
 related entities instead of assuming `xiaomi_miio_fan` services.
 
-### P76 through different integrations
+### One fan, different integrations
 
 The same physical fan can expose different capabilities depending on the
 integration:
 
-- `xiaomi_miio_fan`: P76 angle, vertical oscillation, nudge, timer, LED,
-  buzzer, and child lock actions use registered `xiaomi_miio_fan.*` services.
-- `xiaomi_miot`: P76 angle and vertical controls appear only when Xiaomi MIoT
+- `xiaomi_miio_fan`: angle, vertical oscillation, nudge, timer, LED, buzzer,
+  and child lock actions use registered `xiaomi_miio_fan.*` services.
+- `xiaomi_miot`: angle and vertical controls appear only when Xiaomi MIoT
   exposes actionable same-device related entities. Angle `select` entities
   must provide numeric options such as `30`, `60°`, or `90 degrees`.
 - `auto` and `standard`: the card uses standard fan actions and related
@@ -259,20 +259,20 @@ integration:
 
 The card does not connect directly to Xiaomi devices and does not invent
 MIoT property or service names. If the MIoT integration exposes only primary
-fan attributes, use `xiaomi_miio_fan` for its vendor-specific P76 controls or
-keep those controls hidden.
+fan attributes, use `xiaomi_miio_fan` for its vendor-specific controls or keep
+those controls hidden.
 
 ### Capability safety
 
-Presets and generic fan features do not imply oscillation or angle support. A
-device such as the Xiaomi Smart Air Purifier 4 Pro can expose presets,
-favorite level, LED brightness, sensors, buzzer, child lock, and ionizer while
-having no horizontal or vertical controls. The card keeps those unsupported
-controls hidden.
+Presets and generic fan features do not imply oscillation or angle support. An
+air purifier or air circulator can expose presets, favorite level, LED
+brightness, sensors, buzzer, child lock, and ionizer while having no
+horizontal or vertical controls. The card keeps those unsupported controls
+hidden.
 
 <div align="center">
   <a href="https://raw.githubusercontent.com/mrwogu/xiaomi-smart-fan-card/main/docs/media/integration-modes.webp">
-    <img src="https://raw.githubusercontent.com/mrwogu/xiaomi-smart-fan-card/main/docs/media/integration-modes.webp" alt="The same card for a Xiaomi P76 with angles, timer, and device toggles, then for a plain Home Assistant fan entity with speed, presets, oscillation, and direction only" height="360">
+    <img src="https://raw.githubusercontent.com/mrwogu/xiaomi-smart-fan-card/main/docs/media/integration-modes.webp" alt="The same card for a fully featured fan with angles, timer, and device toggles, then for a plain Home Assistant fan entity with speed, presets, oscillation, and direction only" height="360">
   </a>
 </div>
 
@@ -330,7 +330,7 @@ resources:
 
 ```yaml
 type: custom:xiaomi-fan-card
-entity: fan.xiaomi_smart_standing_fan
+entity: fan.living_room_fan
 name: Living Room Fan
 ```
 
@@ -395,7 +395,7 @@ or angle entities.
 
 ```yaml
 type: custom:xiaomi-fan-card
-entity: fan.air_purifier_4_pro
+entity: fan.bedroom_purifier
 integration: xiaomi_miot
 controls:
   show_horizontal_swing: false

--- a/dist/xiaomi-fan-card.js
+++ b/dist/xiaomi-fan-card.js
@@ -469,6 +469,8 @@ const resolveSpeedLevels = (attributes, profile = getModelProfile()) => {
     return profile.speedLevels;
 };
 
+const FAN_FEATURE_OSCILLATE = 2;
+const FAN_FEATURE_DIRECTION = 4;
 const hasAttribute = (entity, keys) => entity !== undefined && keys.some((key) => Object.prototype.hasOwnProperty.call(entity.attributes, key));
 const hasService = (services, name) => services.loaded && services.names.has(name);
 const customService = (services, name) => hasService(services, `xiaomi_miio_fan.${name}`);
@@ -506,12 +508,12 @@ const detectCapabilities = (entity, services = { loaded: false, names: new Set()
         modelLabel: profile.label,
         speedLevels: resolveSpeedLevels(entity?.attributes ?? {}, profile),
         direction: hasAttribute(entity, ["direction", "current_direction"]) ||
-            hasFanFeature(entity, 16) ||
+            hasFanFeature(entity, FAN_FEATURE_DIRECTION) ||
             hasService(services, "fan.set_direction"),
         sleepMode: Boolean(related.sleepMode) || hasSleepPreset,
         favoriteLevel: Boolean(related.favoriteLevel),
         horizontalSwing: hasAttribute(entity, ["oscillating", "oscillate", "horizontal_swing", "swing_mode"]) ||
-            hasFanFeature(entity, 8) ||
+            hasFanFeature(entity, FAN_FEATURE_OSCILLATE) ||
             (profile.known && profile.isXiaomi && profile.model !== "xiaomi.fan.2lite"),
         horizontalAngle: Boolean(related.horizontalAngle) ||
             (hasHorizontalAngle && customService(services, "fan_set_oscillation_angle")) ||
@@ -573,6 +575,17 @@ const numberValue = (value) => {
     }
     return undefined;
 };
+const angleValue = (value) => {
+    const numeric = numberValue(value);
+    if (numeric !== undefined) {
+        return numeric;
+    }
+    if (typeof value !== "string") {
+        return undefined;
+    }
+    const match = value.trim().match(/^([+-]?(?:\d+(?:\.\d+)?|\.\d+))\s*(?:°|degrees?)?$/i);
+    return match ? Number(match[1]) : undefined;
+};
 const booleanValue$1 = (value) => {
     if (typeof value === "boolean") {
         return value;
@@ -612,6 +625,15 @@ const firstNumber = (attributes, keys) => {
     }
     return undefined;
 };
+const firstAngle = (attributes, keys) => {
+    for (const key of keys) {
+        const value = angleValue(attributes[key]);
+        if (value !== undefined) {
+            return value;
+        }
+    }
+    return undefined;
+};
 const firstBoolean = (attributes, keys) => {
     for (const key of keys) {
         const value = booleanValue$1(attributes[key]);
@@ -630,12 +652,16 @@ const timerMinutes = (attributes) => {
     return timerValueToMinutes(value, unit);
 };
 const ledState = (attributes) => {
+    const brightness = firstNumber(attributes, ["led_brightness"]);
+    if (brightness !== undefined) {
+        return brightness < 2;
+    }
     const direct = firstBoolean(attributes, ["led", "light", "light_enum"]);
     if (direct !== undefined) {
         return direct;
     }
-    const brightness = firstNumber(attributes, ["led_brightness", "light", "led"]);
-    return brightness === undefined ? undefined : brightness < 2;
+    const fallbackBrightness = firstNumber(attributes, ["light", "led"]);
+    return fallbackBrightness === undefined ? undefined : fallbackBrightness < 2;
 };
 const readPresetModes = (...values) => {
     for (const value of values) {
@@ -679,14 +705,14 @@ const normalizeFanState = (entityId, entity) => {
         sleepMode,
         direction: directionValue === "forward" || directionValue === "reverse" ? directionValue : undefined,
         horizontalSwing: firstBoolean(attributes, ["oscillating", "oscillate", "horizontal_swing", "swing_mode"]),
-        horizontalAngle: firstNumber(attributes, [
+        horizontalAngle: firstAngle(attributes, [
             "horizontal_swing_angle",
             "horizontal_angle",
             "swing_mode_angle",
             "angle",
         ]),
         verticalSwing: firstBoolean(attributes, ["vertical_swing", "vertical_oscillate", "vertical_oscillation"]),
-        verticalAngle: firstNumber(attributes, ["vertical_swing_angle", "vertical_oscillation_angle", "vertical_angle"]),
+        verticalAngle: firstAngle(attributes, ["vertical_swing_angle", "vertical_oscillation_angle", "vertical_angle"]),
         timerMinutes: timerMinutes(attributes),
         childLock: booleanValue$1(attributes["child_lock"]),
         led: ledState(attributes),
@@ -744,6 +770,19 @@ const entityParts = (entityId) => {
     const [domain, objectId] = entityId.split(".");
     return [domain ?? "", objectId ?? ""];
 };
+const numericOptionValue = (value) => {
+    const text = typeof value === "string" || typeof value === "number" ? String(value).trim() : "";
+    const match = text.match(/^([+-]?(?:\d+(?:\.\d+)?|\.\d+))\s*(?:°|degrees?)?$/i);
+    return match ? Number(match[1]) : undefined;
+};
+const numericAngleOptions = (entity) => {
+    const options = entity?.attributes["options"];
+    if (!Array.isArray(options)) {
+        return undefined;
+    }
+    const angles = [...new Set(options.map(numericOptionValue).filter((value) => value !== undefined))];
+    return angles.length > 0 ? angles : undefined;
+};
 class StandardFanAdapter {
     constructor(hass, entityId, services, related = {}) {
         this.hass = hass;
@@ -757,12 +796,14 @@ class StandardFanAdapter {
         const detectedCapabilities = detectCapabilities(hass.states[entityId], services, actionableRelated);
         this.capabilities = {
             ...detectedCapabilities,
-            horizontalAngles: detectedCapabilities.horizontalAngles.length > 0
-                ? detectedCapabilities.horizontalAngles
-                : (this.readNumberSteps(this.readTimerSpec(actionableRelated.horizontalAngle)) ?? []),
-            verticalAngles: detectedCapabilities.verticalAngles.length > 0
-                ? detectedCapabilities.verticalAngles
-                : (this.readNumberSteps(this.readTimerSpec(actionableRelated.verticalAngle)) ?? []),
+            horizontalAngles: this.readAngleOptions(actionableRelated.horizontalAngle) ??
+                (detectedCapabilities.horizontalAngles.length > 0
+                    ? detectedCapabilities.horizontalAngles
+                    : (this.readNumberSteps(this.readTimerSpec(actionableRelated.horizontalAngle)) ?? [])),
+            verticalAngles: this.readAngleOptions(actionableRelated.verticalAngle) ??
+                (detectedCapabilities.verticalAngles.length > 0
+                    ? detectedCapabilities.verticalAngles
+                    : (this.readNumberSteps(this.readTimerSpec(actionableRelated.verticalAngle)) ?? [])),
             timerSteps: this.readNumberSteps(actionableRelated.timer ? timerSpec : undefined),
             timerSpec: actionableRelated.timer ? timerSpec : undefined,
         };
@@ -773,11 +814,22 @@ class StandardFanAdapter {
         for (const key of Object.keys(actionable)) {
             const entityId = actionable[key];
             const state = entityId ? this.hass.states[entityId] : undefined;
-            if (!state || state.state === "unknown" || state.state === "unavailable") {
+            if (!state ||
+                state.state === "unknown" ||
+                state.state === "unavailable" ||
+                ((key === "horizontalAngle" || key === "verticalAngle") &&
+                    this.isSelectEntity(entityId) &&
+                    numericAngleOptions(state) === undefined)) {
                 delete actionable[key];
             }
         }
         return actionable;
+    }
+    isSelectEntity(entityId) {
+        return entityId !== undefined && entityParts(entityId)[0] === "select";
+    }
+    readAngleOptions(entityId) {
+        return numericAngleOptions(entityId ? this.hass.states[entityId] : undefined);
     }
     readTimerSpec(entityId) {
         const timerEntity = entityId ? this.hass.states[entityId] : undefined;
@@ -904,7 +956,7 @@ class StandardFanAdapter {
     }
     async setHorizontalAngle(angle) {
         await this.startSwing("horizontal");
-        if (await this.setRelatedValue(this.related.horizontalAngle, angle)) {
+        if (await this.setRelatedAngle(this.related.horizontalAngle, angle)) {
             return;
         }
         await this.callCustom("fan_set_oscillation_angle", { angle });
@@ -917,7 +969,7 @@ class StandardFanAdapter {
     }
     async setVerticalAngle(angle) {
         await this.startSwing("vertical");
-        if (await this.setRelatedValue(this.related.verticalAngle, angle)) {
+        if (await this.setRelatedAngle(this.related.verticalAngle, angle)) {
             return;
         }
         await this.callCustom("fan_set_vertical_oscillation_angle", {
@@ -969,10 +1021,10 @@ class StandardFanAdapter {
         await this.callCustom(enabled ? "fan_set_child_lock_on" : "fan_set_child_lock_off");
     }
     async setLed(enabled) {
-        if (await this.setRelatedBoolean(this.related.led, enabled)) {
+        if (await this.setRelatedLedBrightness(this.related.led, enabled)) {
             return;
         }
-        if (await this.setRelatedLedBrightness(this.related.led, enabled)) {
+        if (await this.setRelatedBoolean(this.related.led, enabled)) {
             return;
         }
         await this.callCustom("fan_set_led_brightness", { brightness: enabled ? 0 : 2 });
@@ -1007,6 +1059,35 @@ class StandardFanAdapter {
             return false;
         }
         await this.hass.callService(domain, "set_value", { entity_id: entityId, value });
+        return true;
+    }
+    async setRelatedAngle(entityId, angle) {
+        if (!entityId) {
+            return false;
+        }
+        const state = this.hass.states[entityId];
+        if (!state || state.state === "unknown" || state.state === "unavailable") {
+            return false;
+        }
+        const [domain] = entityParts(entityId);
+        if (domain === "number" || domain === "input_number") {
+            return this.setRelatedValue(entityId, angle);
+        }
+        if (domain !== "select") {
+            return false;
+        }
+        const options = state.attributes["options"];
+        if (!Array.isArray(options)) {
+            return false;
+        }
+        const option = options.find((candidate) => numericOptionValue(candidate) === angle);
+        if (option === undefined) {
+            return false;
+        }
+        await this.hass.callService("select", "select_option", {
+            entity_id: entityId,
+            option: typeof option === "string" || typeof option === "number" ? String(option) : option,
+        });
         return true;
     }
     async setRelatedBoolean(entityId, enabled) {
@@ -1049,10 +1130,30 @@ class StandardFanAdapter {
             return false;
         }
         const [domain] = entityParts(entityId);
+        const state = this.hass.states[entityId];
+        if (!state || state.state === "unknown" || state.state === "unavailable") {
+            return false;
+        }
+        if (domain === "select") {
+            const options = state.attributes["options"];
+            const availableOptions = Array.isArray(options) ? options.map(String) : [];
+            const numericTarget = enabled ? 0 : 2;
+            const option = availableOptions.find((candidate) => numericOptionValue(candidate) === numericTarget) ??
+                availableOptions.find((candidate) => (enabled
+                    ? ["on", "true", "enable", "bright", "active"]
+                    : ["off", "false", "disable", "dim", "inactive"]).some((token) => candidate.toLowerCase().includes(token)));
+            if (option === undefined) {
+                return false;
+            }
+            await this.hass.callService("select", "select_option", {
+                entity_id: entityId,
+                option,
+            });
+            return true;
+        }
         if (domain !== "number" && domain !== "input_number") {
             return false;
         }
-        const state = this.hass.states[entityId];
         const minimum = Number(state?.attributes["min"]);
         const maximum = Number(state?.attributes["max"]);
         if (!state ||
@@ -1391,9 +1492,9 @@ const normalizeCardConfig = (raw) => {
 };
 
 const RELATED_ENTITY_DOMAINS = {
-    horizontal_angle_entity: ["number", "input_number"],
+    horizontal_angle_entity: ["number", "input_number", "select"],
     vertical_swing_entity: ["switch", "input_boolean", "select"],
-    vertical_angle_entity: ["number", "input_number"],
+    vertical_angle_entity: ["number", "input_number", "select"],
     favorite_level_entity: ["number", "input_number"],
     sleep_mode_entity: ["switch", "input_boolean", "select"],
     timer_entity: ["number", "input_number"],
@@ -2575,8 +2676,8 @@ const suffixes = {
     led: ["_led", "_led_brightness", "_light"],
     buzzer: ["_buzzer", "_notification_sound"],
     ionizer: ["_anion", "_ionizer"],
-    temperature: ["_temperature"],
-    humidity: ["_humidity"],
+    temperature: ["_temperature", "_temperatuur"],
+    humidity: ["_humidity", "_luchtvochtigheid"],
 };
 const findBySuffix = (entries, allowedDomains, wantedSuffixes) => {
     const candidates = entries.filter((entry) => {
@@ -2611,12 +2712,13 @@ const resolveRelatedEntities = async (hass, entityId) => {
         const entries = registry.filter((entry) => entry.device_id === primary.device_id);
         const related = {};
         const numeric = ["number", "input_number"];
+        const angle = [...numeric, "select"];
         const boolean = ["switch", "input_boolean"];
         const select = ["select"];
-        related.horizontalAngle = findBySuffix(entries, numeric, suffixes.horizontalAngle);
+        related.horizontalAngle = findBySuffix(entries, angle, suffixes.horizontalAngle);
         related.sleepMode = findBySuffix(entries, [...boolean, "select"], suffixes.sleepMode);
         related.verticalSwing = findBySuffix(entries, [...boolean, "select"], suffixes.verticalSwing);
-        related.verticalAngle = findBySuffix(entries, numeric, suffixes.verticalAngle);
+        related.verticalAngle = findBySuffix(entries, angle, suffixes.verticalAngle);
         related.favoriteLevel = findBySuffix(entries, numeric, suffixes.favoriteLevel);
         related.timer = findBySuffix(entries, numeric, suffixes.timer);
         related.childLock = findBySuffix(entries, [...boolean, ...select], suffixes.childLock);

--- a/dist/xiaomi-fan-card.js
+++ b/dist/xiaomi-fan-card.js
@@ -575,7 +575,11 @@ const numberValue = (value) => {
     }
     return undefined;
 };
-const angleValue = (value) => {
+/**
+ * Integrations expose numbers bare or wrapped in a unit label such as `90°`
+ * and `60 degrees`, which is how select options usually arrive.
+ */
+const numericLabel = (value) => {
     const numeric = numberValue(value);
     if (numeric !== undefined) {
         return numeric;
@@ -627,7 +631,7 @@ const firstNumber = (attributes, keys) => {
 };
 const firstAngle = (attributes, keys) => {
     for (const key of keys) {
-        const value = angleValue(attributes[key]);
+        const value = numericLabel(attributes[key]);
         if (value !== undefined) {
             return value;
         }
@@ -766,25 +770,61 @@ class ServiceDispatcher {
     }
 }
 
+/**
+ * A dropdown turns unusable well before a fine-grained angle entity runs out of
+ * steps, so a wider range reports its raw spec instead of a preset list.
+ */
+const MAX_ANGLE_STEPS = 24;
+const MAX_TIMER_STEPS = 100;
 const entityParts = (entityId) => {
     const [domain, objectId] = entityId.split(".");
     return [domain ?? "", objectId ?? ""];
-};
-const numericOptionValue = (value) => {
-    const text = typeof value === "string" || typeof value === "number" ? String(value).trim() : "";
-    const match = text.match(/^([+-]?(?:\d+(?:\.\d+)?|\.\d+))\s*(?:°|degrees?)?$/i);
-    return match ? Number(match[1]) : undefined;
 };
 const numericOptions = (options) => {
     if (!Array.isArray(options)) {
         return undefined;
     }
-    const angles = [
-        ...new Set(options.map(numericOptionValue).filter((value) => value !== undefined)),
-    ].sort((left, right) => left - right);
+    const angles = [...new Set(options.map(numericLabel).filter((value) => value !== undefined))].sort((left, right) => left - right);
     return angles.length > 0 ? angles : undefined;
 };
 const numericAngleOptions = (entity) => numericOptions(entity?.attributes["options"]);
+const selectOptions = (entity) => {
+    const options = entity?.attributes["options"];
+    return Array.isArray(options) ? options.map(String) : [];
+};
+/**
+ * Exact labels win over substring hints because a substring search returns the
+ * first matching option rather than the closest one: `Dim` would answer a
+ * request for `Off`, and `on` hides inside words such as `None`.
+ */
+const selectOptionFor = (options, exact, hints) => {
+    const normalized = options.map((option) => ({ option, key: option.trim().toLowerCase() }));
+    for (const label of exact) {
+        const match = normalized.find((entry) => entry.key === label);
+        if (match) {
+            return match.option;
+        }
+    }
+    for (const hint of hints) {
+        const match = normalized.find((entry) => entry.key.includes(hint));
+        if (match) {
+            return match.option;
+        }
+    }
+    return undefined;
+};
+const rawSteps = (spec) => Array.from({ length: Math.floor((spec.max - spec.min) / spec.step) + 1 }, (_, index) => spec.min + index * spec.step);
+const roundStep = (value) => Math.round(value * 100) / 100;
+const BOOLEAN_SELECT_LABELS = {
+    enabledExact: ["on", "true", "yes", "enable", "enabled"],
+    enabledHints: ["bright", "enable", "active", "sleep", "oscillate", "swing", "true"],
+    disabledExact: ["off", "false", "no", "disable", "disabled"],
+    disabledHints: ["off", "disable", "inactive", "false", "none", "normal", "fixed", "static", "dim"],
+};
+const isDisabledLabel = (value) => selectOptionFor([value], BOOLEAN_SELECT_LABELS.disabledExact, ["off", "disable", "inactive"]) !== undefined;
+const booleanSelectOption = (options, enabled) => enabled
+    ? selectOptionFor(options, BOOLEAN_SELECT_LABELS.enabledExact, BOOLEAN_SELECT_LABELS.enabledHints)
+    : selectOptionFor(options, BOOLEAN_SELECT_LABELS.disabledExact, BOOLEAN_SELECT_LABELS.disabledHints);
 class StandardFanAdapter {
     constructor(hass, entityId, services, related = {}) {
         this.hass = hass;
@@ -801,11 +841,13 @@ class StandardFanAdapter {
             horizontalAngles: this.readAngleOptions(actionableRelated.horizontalAngle) ??
                 (detectedCapabilities.horizontalAngles.length > 0
                     ? detectedCapabilities.horizontalAngles
-                    : (this.readNumberSteps(this.readTimerSpec(actionableRelated.horizontalAngle)) ?? [])),
+                    : (this.readAngleSteps(actionableRelated.horizontalAngle) ?? [])),
+            horizontalAngleSpec: this.readNumberSpec(actionableRelated.horizontalAngle),
             verticalAngles: this.readAngleOptions(actionableRelated.verticalAngle) ??
                 (detectedCapabilities.verticalAngles.length > 0
                     ? detectedCapabilities.verticalAngles
-                    : (this.readNumberSteps(this.readTimerSpec(actionableRelated.verticalAngle)) ?? [])),
+                    : (this.readAngleSteps(actionableRelated.verticalAngle) ?? [])),
+            verticalAngleSpec: this.readNumberSpec(actionableRelated.verticalAngle),
             timerSteps: this.readNumberSteps(actionableRelated.timer ? timerSpec : undefined),
             timerSpec: actionableRelated.timer ? timerSpec : undefined,
         };
@@ -833,27 +875,45 @@ class StandardFanAdapter {
     readAngleOptions(entityId) {
         return numericAngleOptions(entityId ? this.hass.states[entityId] : undefined);
     }
-    readTimerSpec(entityId) {
-        const timerEntity = entityId ? this.hass.states[entityId] : undefined;
-        const minimum = Number(timerEntity?.attributes["min"]);
-        const maximum = Number(timerEntity?.attributes["max"]);
-        const step = Number(timerEntity?.attributes["step"]);
+    readNumberSpec(entityId) {
+        const entity = entityId ? this.hass.states[entityId] : undefined;
+        const minimum = Number(entity?.attributes["min"]);
+        const maximum = Number(entity?.attributes["max"]);
+        const step = Number(entity?.attributes["step"]);
         if (!Number.isFinite(minimum) ||
             !Number.isFinite(maximum) ||
             !Number.isFinite(step) ||
             step <= 0 ||
-            maximum < minimum ||
-            (maximum - minimum) / step > 100) {
+            maximum < minimum) {
             return undefined;
         }
-        const unit = parseTimerUnit(timerEntity?.attributes["unit_of_measurement"]);
-        return { unit, min: minimum, max: maximum, step };
+        return { min: minimum, max: maximum, step };
+    }
+    readTimerSpec(entityId) {
+        const spec = this.readNumberSpec(entityId);
+        if (!spec || (spec.max - spec.min) / spec.step > MAX_TIMER_STEPS) {
+            return undefined;
+        }
+        const entity = entityId ? this.hass.states[entityId] : undefined;
+        return { ...spec, unit: parseTimerUnit(entity?.attributes["unit_of_measurement"]) };
+    }
+    /**
+     * Angles carry no timer unit, so they never go through the timer conversion.
+     * A range too wide for a dropdown reports no presets and leaves the card on
+     * the bounded numeric input built from the same spec.
+     */
+    readAngleSteps(entityId) {
+        const spec = this.readNumberSpec(entityId);
+        if (!spec || (spec.max - spec.min) / spec.step > MAX_ANGLE_STEPS) {
+            return undefined;
+        }
+        return rawSteps(spec).map(roundStep);
     }
     readNumberSteps(spec) {
         if (!spec) {
             return undefined;
         }
-        return Array.from({ length: Math.floor((spec.max - spec.min) / spec.step) + 1 }, (_, index) => Math.round(timerValueToMinutes(spec.min + index * spec.step, spec.unit) * 100) / 100);
+        return rawSteps(spec).map((value) => roundStep(timerValueToMinutes(value, spec.unit)));
     }
     entityWithRelatedAttributes(related, timerSpec) {
         const entity = this.hass.states[this.entityId];
@@ -884,6 +944,12 @@ class StandardFanAdapter {
                     delete attributes["led_brightness"];
                     continue;
                 }
+                // A mode selector matched as an angle entity carries no angle, so the
+                // primary attribute stays authoritative instead of being overwritten.
+                if ((relatedKey === "horizontalAngle" || relatedKey === "verticalAngle") &&
+                    numericLabel(relatedState.state) === undefined) {
+                    continue;
+                }
                 const value = Number(relatedState.state);
                 attributes[attributeKey] =
                     relatedKey === "timer" && Number.isFinite(value) && timerSpec
@@ -904,7 +970,7 @@ class StandardFanAdapter {
     }
     readRelatedLedState(entityId, entity) {
         const [domain] = entityParts(entityId);
-        const current = numericOptionValue(entity.state);
+        const current = numericLabel(entity.state);
         if (domain === "number" || domain === "input_number") {
             const minimum = Number(entity.attributes["min"]);
             const maximum = Number(entity.attributes["max"]);
@@ -917,6 +983,8 @@ class StandardFanAdapter {
             if (current !== undefined && options.includes(0) && options.includes(2)) {
                 return current < 2;
             }
+            // A dimmed LED is still lit, so only an explicit off label reads as off.
+            return !isDisabledLabel(entity.state);
         }
         return entity.state;
     }
@@ -1101,17 +1169,13 @@ class StandardFanAdapter {
         if (domain !== "select") {
             return false;
         }
-        const options = state.attributes["options"];
-        if (!Array.isArray(options)) {
-            return false;
-        }
-        const option = options.find((candidate) => numericOptionValue(candidate) === angle);
+        const option = selectOptions(state).find((candidate) => numericLabel(candidate) === angle);
         if (option === undefined) {
             return false;
         }
         await this.hass.callService("select", "select_option", {
             entity_id: entityId,
-            option: typeof option === "string" || typeof option === "number" ? String(option) : option,
+            option,
         });
         return true;
     }
@@ -1129,17 +1193,12 @@ class StandardFanAdapter {
             return true;
         }
         if (domain === "select") {
-            const options = this.hass.states[entityId]?.attributes["options"];
-            const availableOptions = Array.isArray(options) ? options.map(String) : [];
-            const enabledOptions = ["on", "true", "enable", "sleep", "bright", "active", "oscillate", "swing"];
-            const disabledOptions = ["off", "false", "disable", "normal", "none", "dim", "fixed", "static"];
-            const option = enabled
-                ? (availableOptions.find((candidate) => enabledOptions.some((token) => candidate.toLowerCase().includes(token))) ?? "on")
-                : (availableOptions.find((candidate) => disabledOptions.some((token) => candidate.toLowerCase().includes(token))) ?? "off");
+            const availableOptions = selectOptions(state);
             if (availableOptions.length === 0) {
                 throw new Error(`Related select ${entityId} has no valid options.`);
             }
-            if (!availableOptions.includes(option)) {
+            const option = booleanSelectOption(availableOptions, enabled);
+            if (option === undefined) {
                 throw new Error(`Related select ${entityId} has no matching boolean option.`);
             }
             await this.hass.callService(domain, "select_option", {
@@ -1160,13 +1219,10 @@ class StandardFanAdapter {
             return false;
         }
         if (domain === "select") {
-            const options = state.attributes["options"];
-            const availableOptions = Array.isArray(options) ? options.map(String) : [];
+            const availableOptions = selectOptions(state);
             const numericTarget = enabled ? 0 : 2;
-            const option = availableOptions.find((candidate) => numericOptionValue(candidate) === numericTarget) ??
-                availableOptions.find((candidate) => (enabled
-                    ? ["on", "true", "enable", "bright", "active"]
-                    : ["off", "false", "disable", "dim", "inactive"]).some((token) => candidate.toLowerCase().includes(token)));
+            const option = availableOptions.find((candidate) => numericLabel(candidate) === numericTarget) ??
+                booleanSelectOption(availableOptions, enabled);
             if (option === undefined) {
                 return false;
             }
@@ -2701,8 +2757,8 @@ const suffixes = {
     led: ["_led", "_led_brightness", "_light"],
     buzzer: ["_buzzer", "_notification_sound"],
     ionizer: ["_anion", "_ionizer"],
-    temperature: ["_temperature", "_temperatuur"],
-    humidity: ["_humidity", "_luchtvochtigheid"],
+    temperature: ["_temperature"],
+    humidity: ["_humidity"],
 };
 const findBySuffix = (entries, allowedDomains, wantedSuffixes) => {
     const candidates = entries.filter((entry) => {
@@ -2718,6 +2774,21 @@ const findBySuffix = (entries, allowedDomains, wantedSuffixes) => {
         const searchable = `${entry.entity_id} ${entry.name ?? ""} ${entry.original_name ?? ""}`.toLowerCase();
         return hintGroups.some((hints) => hints.every((hint) => searchable.includes(hint.toLowerCase())));
     })?.entity_id;
+};
+/**
+ * A translated Home Assistant install names sensors in the user language, so a
+ * suffix table would need one entry per locale. The device class is the same
+ * in every language and only falls back to the suffix search when missing.
+ */
+const findSensorByDeviceClass = (hass, entries, deviceClass, fallbackSuffixes) => {
+    const match = entries.find((entry) => {
+        if (!entry.entity_id.startsWith("sensor.")) {
+            return false;
+        }
+        const registered = entry.device_class ?? entry.original_device_class;
+        return registered === deviceClass || hass.states[entry.entity_id]?.attributes["device_class"] === deviceClass;
+    });
+    return match?.entity_id ?? findBySuffix(entries, ["sensor"], fallbackSuffixes);
 };
 /**
  * Resolves to undefined when the registry lookup itself failed, which is what
@@ -2740,11 +2811,15 @@ const resolveRelatedEntities = async (hass, entityId) => {
         const angle = [...numeric, "select"];
         const boolean = ["switch", "input_boolean"];
         const select = ["select"];
+        // The vertical angle resolves first and then drops out of the remaining
+        // searches: `_vertical_oscillation_angle` also ends with the horizontal
+        // `_oscillation_angle`, and both angle names contain the vertical swing
+        // hints once a `select` angle entity is allowed.
         related.verticalAngle = findBySuffix(entries, angle, suffixes.verticalAngle);
         const withoutVerticalAngle = entries.filter((entry) => entry.entity_id !== related.verticalAngle);
         related.horizontalAngle = findBySuffix(withoutVerticalAngle, angle, suffixes.horizontalAngle);
         const withoutAngles = withoutVerticalAngle.filter((entry) => entry.entity_id !== related.horizontalAngle);
-        related.sleepMode = findBySuffix(entries, [...boolean, "select"], suffixes.sleepMode);
+        related.sleepMode = findBySuffix(withoutAngles, [...boolean, "select"], suffixes.sleepMode);
         related.verticalSwing = findBySuffix(withoutAngles, [...boolean, "select"], suffixes.verticalSwing);
         related.favoriteLevel = findBySuffix(entries, numeric, suffixes.favoriteLevel);
         related.timer = findBySuffix(entries, numeric, suffixes.timer);
@@ -2752,8 +2827,8 @@ const resolveRelatedEntities = async (hass, entityId) => {
         related.led = findBySuffix(entries, [...boolean, ...select, ...numeric], suffixes.led);
         related.buzzer = findBySuffix(entries, [...boolean, ...select], suffixes.buzzer);
         related.ionizer = findBySuffix(entries, [...boolean, ...select], suffixes.ionizer);
-        related.temperature = findBySuffix(entries, ["sensor"], suffixes.temperature);
-        related.humidity = findBySuffix(entries, ["sensor"], suffixes.humidity);
+        related.temperature = findSensorByDeviceClass(hass, entries, "temperature", suffixes.temperature);
+        related.humidity = findSensorByDeviceClass(hass, entries, "humidity", suffixes.humidity);
         return related;
     }
     catch {
@@ -3038,11 +3113,7 @@ class XiaomiFanCard extends i$2 {
             ? (this.config.horizontal_angle_entity ?? this.related.horizontalAngle)
             : (this.config.vertical_angle_entity ?? this.related.verticalAngle);
         const raw = entityId ? this.hass?.states[entityId]?.state : undefined;
-        if (typeof raw !== "string" || raw.trim() === "") {
-            return fallback;
-        }
-        const value = Number(raw);
-        return Number.isFinite(value) ? value : fallback;
+        return numericLabel(raw) ?? fallback;
     }
     withConfiguredRelatedEntities(discovered) {
         return {
@@ -3464,13 +3535,13 @@ class XiaomiFanCard extends i$2 {
             const angles = adapter.capabilities.horizontalAngles;
             angleFeatures.push(controls.angle_mode === "cycle" && angles.length > 0
                 ? this.renderAngleCycleButton(this.t("horizontalAngle"), horizontalAngle, angles, (angle) => this.execute(() => adapter.setHorizontalAngle(angle)), "mdi:arrow-left-right")
-                : this.renderAngleControl(this.t("horizontalAngle"), horizontalAngle, angles, (angle) => this.execute(() => adapter.setHorizontalAngle(angle))));
+                : this.renderAngleControl(this.t("horizontalAngle"), horizontalAngle, angles, (angle) => this.execute(() => adapter.setHorizontalAngle(angle)), adapter.capabilities.horizontalAngleSpec));
         }
         if (controls.show_vertical_angle && adapter.capabilities.verticalAngle) {
             const angles = adapter.capabilities.verticalAngles;
             angleFeatures.push(controls.angle_mode === "cycle" && angles.length > 0
                 ? this.renderAngleCycleButton(this.t("verticalAngle"), verticalAngle, angles, (angle) => this.execute(() => adapter.setVerticalAngle(angle)), "mdi:swap-vertical")
-                : this.renderAngleControl(this.t("verticalAngle"), verticalAngle, angles, (angle) => this.execute(() => adapter.setVerticalAngle(angle))));
+                : this.renderAngleControl(this.t("verticalAngle"), verticalAngle, angles, (angle) => this.execute(() => adapter.setVerticalAngle(angle)), adapter.capabilities.verticalAngleSpec));
         }
         const hasAutomaticAngle = (controls.show_horizontal_angle && adapter.capabilities.horizontalAngle) ||
             (controls.show_vertical_angle && adapter.capabilities.verticalAngle);
@@ -3655,8 +3726,8 @@ class XiaomiFanCard extends i$2 {
       </label>
     `;
     }
-    renderAngleControl(label, value, angles, onChange) {
-        const current = value ?? angles[0] ?? 0;
+    renderAngleControl(label, value, angles, onChange, spec) {
+        const current = value ?? angles[0] ?? spec?.min ?? 0;
         const options = angles.includes(current) ? angles : [...angles, current].sort((left, right) => left - right);
         return b `
       <label class="feature-select">
@@ -3674,9 +3745,9 @@ class XiaomiFanCard extends i$2 {
             : b `
                 <input
                   type="number"
-                  min="0"
-                  max="360"
-                  step="1"
+                  min=${spec?.min ?? 0}
+                  max=${spec?.max ?? 360}
+                  step=${spec?.step ?? 1}
                   .value=${String(current)}
                   @change=${(event) => onChange(Number(event.currentTarget.value))}
                   aria-label=${label}

--- a/dist/xiaomi-fan-card.js
+++ b/dist/xiaomi-fan-card.js
@@ -775,14 +775,16 @@ const numericOptionValue = (value) => {
     const match = text.match(/^([+-]?(?:\d+(?:\.\d+)?|\.\d+))\s*(?:°|degrees?)?$/i);
     return match ? Number(match[1]) : undefined;
 };
-const numericAngleOptions = (entity) => {
-    const options = entity?.attributes["options"];
+const numericOptions = (options) => {
     if (!Array.isArray(options)) {
         return undefined;
     }
-    const angles = [...new Set(options.map(numericOptionValue).filter((value) => value !== undefined))];
+    const angles = [
+        ...new Set(options.map(numericOptionValue).filter((value) => value !== undefined)),
+    ].sort((left, right) => left - right);
     return angles.length > 0 ? angles : undefined;
 };
+const numericAngleOptions = (entity) => numericOptions(entity?.attributes["options"]);
 class StandardFanAdapter {
     constructor(hass, entityId, services, related = {}) {
         this.hass = hass;
@@ -876,15 +878,17 @@ class StandardFanAdapter {
         for (const [relatedKey, attributeKey] of relatedValues) {
             const relatedEntityId = related[relatedKey];
             const relatedState = relatedEntityId ? this.hass.states[relatedEntityId] : undefined;
-            if (relatedState && relatedState.state !== "unknown" && relatedState.state !== "unavailable") {
+            if (relatedEntityId && relatedState && relatedState.state !== "unknown" && relatedState.state !== "unavailable") {
+                if (relatedKey === "led") {
+                    attributes[attributeKey] = this.readRelatedLedState(relatedEntityId, relatedState);
+                    delete attributes["led_brightness"];
+                    continue;
+                }
                 const value = Number(relatedState.state);
                 attributes[attributeKey] =
                     relatedKey === "timer" && Number.isFinite(value) && timerSpec
                         ? timerValueToMinutes(value, timerSpec.unit)
                         : relatedState.state;
-                if (relatedKey === "led") {
-                    attributes["led_brightness"] = relatedState.state;
-                }
             }
             else if (relatedState) {
                 delete attributes[attributeKey];
@@ -897,6 +901,27 @@ class StandardFanAdapter {
             }
         }
         return { ...entity, attributes };
+    }
+    readRelatedLedState(entityId, entity) {
+        const [domain] = entityParts(entityId);
+        const current = numericOptionValue(entity.state);
+        if (domain === "number" || domain === "input_number") {
+            const minimum = Number(entity.attributes["min"]);
+            const maximum = Number(entity.attributes["max"]);
+            if (current !== undefined && Number.isFinite(minimum) && Number.isFinite(maximum) && maximum >= minimum) {
+                return this.isCustomLedBrightnessMapping(entityId, minimum, maximum) ? current < 2 : current > minimum;
+            }
+        }
+        if (domain === "select") {
+            const options = numericOptions(entity.attributes["options"]) ?? [];
+            if (current !== undefined && options.includes(0) && options.includes(2)) {
+                return current < 2;
+            }
+        }
+        return entity.state;
+    }
+    isCustomLedBrightnessMapping(entityId, minimum, maximum) {
+        return entityId.endsWith("_led_brightness") && minimum === 0 && maximum === 2;
     }
     async togglePower() {
         await this.dispatcher.standard("toggle");
@@ -1164,7 +1189,7 @@ class StandardFanAdapter {
             maximum < minimum) {
             return false;
         }
-        const customBrightnessMapping = entityId.endsWith("_led_brightness") && minimum === 0 && maximum === 2;
+        const customBrightnessMapping = this.isCustomLedBrightnessMapping(entityId, minimum, maximum);
         await this.hass.callService(domain, "set_value", {
             entity_id: entityId,
             value: enabled ? (customBrightnessMapping ? minimum : maximum) : customBrightnessMapping ? maximum : minimum,
@@ -2715,10 +2740,12 @@ const resolveRelatedEntities = async (hass, entityId) => {
         const angle = [...numeric, "select"];
         const boolean = ["switch", "input_boolean"];
         const select = ["select"];
-        related.horizontalAngle = findBySuffix(entries, angle, suffixes.horizontalAngle);
-        related.sleepMode = findBySuffix(entries, [...boolean, "select"], suffixes.sleepMode);
-        related.verticalSwing = findBySuffix(entries, [...boolean, "select"], suffixes.verticalSwing);
         related.verticalAngle = findBySuffix(entries, angle, suffixes.verticalAngle);
+        const withoutVerticalAngle = entries.filter((entry) => entry.entity_id !== related.verticalAngle);
+        related.horizontalAngle = findBySuffix(withoutVerticalAngle, angle, suffixes.horizontalAngle);
+        const withoutAngles = withoutVerticalAngle.filter((entry) => entry.entity_id !== related.horizontalAngle);
+        related.sleepMode = findBySuffix(entries, [...boolean, "select"], suffixes.sleepMode);
+        related.verticalSwing = findBySuffix(withoutAngles, [...boolean, "select"], suffixes.verticalSwing);
         related.favoriteLevel = findBySuffix(entries, numeric, suffixes.favoriteLevel);
         related.timer = findBySuffix(entries, numeric, suffixes.timer);
         related.childLock = findBySuffix(entries, [...boolean, ...select], suffixes.childLock);

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -54,15 +54,9 @@ optional angle controls require a discovered or configured related `select`,
 attributes alone are not treated as angle actions.
 
 The `controls.show_horizontal_*` and `controls.show_vertical_*` options are
-visibility switches, not capability overrides. For the issue #26 purifier
-case, disable the unsupported horizontal or vertical controls explicitly.
-
-Automatic discovery requires the related entity to share the primary fan
-`device_id` and use a recognized suffix. Manual related entity configuration
-handles integrations with different names or incomplete registries. Known
-localized sensor suffixes include `_temperatuur` and `_luchtvochtigheid`.
-Numeric angle select options can be written as `30`, `30°`, or `30 degrees`;
-other select options do not advertise angle support.
+visibility switches, not capability overrides. See
+[docs/configuration.md](configuration.md) for the discovery rules and the
+control visibility contract.
 
 ### P76 integration matrix
 
@@ -78,10 +72,9 @@ button from claiming support that Home Assistant cannot execute.
 
 ### Xiaomi Smart Air Purifier 4 Pro
 
-The issue #26 entity set exposes presets and optional device entities but no
-horizontal or vertical swing or angle entity. Preset-only
-`supported_features` values do not imply oscillation. The expected
-configuration is:
+This purifier exposes presets and optional device entities but no horizontal
+or vertical swing or angle entity. Preset-only `supported_features` values do
+not imply oscillation. The expected configuration is:
 
 ```yaml
 type: custom:xiaomi-fan-card

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -10,7 +10,7 @@ control only when it has a usable source.
 | -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | Power, percentage, presets, horizontal oscillation | Standard `fan` entity actions and attributes                                                                                                  |
 | Horizontal angle                                   | Live fan attribute, model profile with registered Xiaomi service, or related `number`, `input_number`, or `select` with numeric angle options |
-| Vertical oscillation and angle                     | Live attributes, P70 or P76 model profile with registered Xiaomi services, or related `number`, `input_number`, or `select` entities          |
+| Vertical oscillation and angle                     | Live attributes, a model profile that declares them plus the registered Xiaomi services, or related `number`, `input_number`, or `select`     |
 | Sleep mode                                         | Sleep preset, related `switch`, `input_boolean`, or `select`                                                                                  |
 | Timer                                              | Live timer attribute with registered service, related `number` or `input_number`, or registered Xiaomi delay service                          |
 | Child lock, buzzer, ionizer                        | Related switch, input boolean, or select, or registered Xiaomi service                                                                        |
@@ -58,27 +58,32 @@ visibility switches, not capability overrides. See
 [docs/configuration.md](configuration.md) for the discovery rules and the
 control visibility contract.
 
-### P76 integration matrix
+### Fans with vertical oscillation or angle presets
 
-| P76 integration      | Vertical and angle behavior                                                              |
+The same device reaches these controls through a different path depending on
+the selected integration:
+
+| `integration`        | Vertical and angle behavior                                                              |
 | -------------------- | ---------------------------------------------------------------------------------------- |
-| `xiaomi_miio_fan`    | Uses registered `xiaomi_miio_fan.*` actions and the P76 model profile.                   |
+| `xiaomi_miio_fan`    | Uses registered `xiaomi_miio_fan.*` actions and the model profile ranges.                |
 | `xiaomi_miot`        | Uses standard fan actions plus same-device related switch/select/number entities.        |
 | `auto` or `standard` | Uses standard fan actions and related entities; does not invent vendor-specific actions. |
 
-If Xiaomi MIOT exposes only P76 attributes without related action entities,
-the card intentionally hides vertical and angle controls. This prevents a
-button from claiming support that Home Assistant cannot execute.
+When an integration exposes vertical or angle values as read-only attributes
+without a matching action entity or service, the card hides those controls.
+This prevents a button from claiming support that Home Assistant cannot
+execute.
 
-### Xiaomi Smart Air Purifier 4 Pro
+### Fans without oscillation or angle support
 
-This purifier exposes presets and optional device entities but no horizontal
-or vertical swing or angle entity. Preset-only `supported_features` values do
-not imply oscillation. The expected configuration is:
+An air purifier, air circulator, or exhaust fan often exposes presets and
+optional device entities while having no swing or angle entity at all. A
+preset-only `supported_features` value does not imply oscillation. Hide the
+unsupported controls explicitly:
 
 ```yaml
 type: custom:xiaomi-fan-card
-entity: fan.air_purifier_4_pro
+entity: fan.bedroom_purifier
 integration: xiaomi_miot
 controls:
   show_horizontal_swing: false
@@ -95,9 +100,10 @@ details:
 ## Model coverage
 
 Known profiles cover families including `zhimi.fan.*`, `dmaker.fan.*`,
-`xiaomi.fan.*`, and `leshow.fan.ss4`. P70 and P76 profiles include vertical
-oscillation and angle ranges. Unknown models use live attributes and
-registered services without inventing unsupported controls.
+`xiaomi.fan.*`, and `leshow.fan.ss4`. A profile only declares the speed levels,
+angle ranges, and vertical oscillation that its family supports. Unknown models
+use live attributes and registered services without inventing unsupported
+controls.
 
 Model profiles describe UI ranges, not device communication. The card never
 connects directly to a Xiaomi device.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -6,23 +6,30 @@ control only when it has a usable source.
 
 ## Capability sources
 
-| Capability                                         | Accepted source                                                                                                      |
-| -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| Power, percentage, presets, horizontal oscillation | Standard `fan` entity actions and attributes                                                                         |
-| Horizontal angle                                   | Live fan attribute, model profile with registered Xiaomi service, or related `number` or `input_number`              |
-| Vertical oscillation and angle                     | Live attributes, P70 or P76 model profile with registered Xiaomi services, or related entities                       |
-| Sleep mode                                         | Sleep preset, related `switch`, `input_boolean`, or `select`                                                         |
-| Timer                                              | Live timer attribute with registered service, related `number` or `input_number`, or registered Xiaomi delay service |
-| Child lock, buzzer, ionizer                        | Related switch, input boolean, or select, or registered Xiaomi service                                               |
-| LED                                                | Related switch, input boolean, select, number, or input number, or registered Xiaomi LED service                     |
-| Temperature and humidity                           | Fan attributes or related sensors                                                                                    |
-| Nudge                                              | Known model profile plus the registered Xiaomi nudge service                                                         |
+| Capability                                         | Accepted source                                                                                                                               |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Power, percentage, presets, horizontal oscillation | Standard `fan` entity actions and attributes                                                                                                  |
+| Horizontal angle                                   | Live fan attribute, model profile with registered Xiaomi service, or related `number`, `input_number`, or `select` with numeric angle options |
+| Vertical oscillation and angle                     | Live attributes, P70 or P76 model profile with registered Xiaomi services, or related `number`, `input_number`, or `select` entities          |
+| Sleep mode                                         | Sleep preset, related `switch`, `input_boolean`, or `select`                                                                                  |
+| Timer                                              | Live timer attribute with registered service, related `number` or `input_number`, or registered Xiaomi delay service                          |
+| Child lock, buzzer, ionizer                        | Related switch, input boolean, or select, or registered Xiaomi service                                                                        |
+| LED                                                | Related switch, input boolean, select, number, or input number, or registered Xiaomi LED service                                              |
+| Temperature and humidity                           | Fan attributes or related sensors                                                                                                             |
+| Nudge                                              | Known model profile plus the registered Xiaomi nudge service                                                                                  |
 
 Missing, unknown, and unavailable related entities are ignored for actions.
 Unavailable related values also remove stale copied values from the displayed
 state.
 
 ## Integration notes
+
+### Auto detection and standard fans
+
+`auto` and `standard` use public Home Assistant fan actions and related entity
+discovery. They do not assume an integration-specific service. An optional
+control appears only when the primary fan, a related entity, a model profile,
+or a registered standard action makes it actionable.
 
 ### Native Xiaomi Home
 
@@ -41,7 +48,56 @@ nudge, timer, LED, buzzer, child lock, and ionizer actions.
 
 Use `integration: xiaomi_miot` or `integration: standard` when the integration
 exposes a normal Home Assistant `fan` entity. Configure `related_entities`
-when automatic entity discovery cannot identify an optional control.
+when automatic entity discovery cannot identify an optional control. MIoT
+optional angle controls require a discovered or configured related `select`,
+`number`, or `input_number` entity with numeric angle options. MIoT primary fan
+attributes alone are not treated as angle actions.
+
+The `controls.show_horizontal_*` and `controls.show_vertical_*` options are
+visibility switches, not capability overrides. For the issue #26 purifier
+case, disable the unsupported horizontal or vertical controls explicitly.
+
+Automatic discovery requires the related entity to share the primary fan
+`device_id` and use a recognized suffix. Manual related entity configuration
+handles integrations with different names or incomplete registries. Known
+localized sensor suffixes include `_temperatuur` and `_luchtvochtigheid`.
+Numeric angle select options can be written as `30`, `30°`, or `30 degrees`;
+other select options do not advertise angle support.
+
+### P76 integration matrix
+
+| P76 integration      | Vertical and angle behavior                                                              |
+| -------------------- | ---------------------------------------------------------------------------------------- |
+| `xiaomi_miio_fan`    | Uses registered `xiaomi_miio_fan.*` actions and the P76 model profile.                   |
+| `xiaomi_miot`        | Uses standard fan actions plus same-device related switch/select/number entities.        |
+| `auto` or `standard` | Uses standard fan actions and related entities; does not invent vendor-specific actions. |
+
+If Xiaomi MIOT exposes only P76 attributes without related action entities,
+the card intentionally hides vertical and angle controls. This prevents a
+button from claiming support that Home Assistant cannot execute.
+
+### Xiaomi Smart Air Purifier 4 Pro
+
+The issue #26 entity set exposes presets and optional device entities but no
+horizontal or vertical swing or angle entity. Preset-only
+`supported_features` values do not imply oscillation. The expected
+configuration is:
+
+```yaml
+type: custom:xiaomi-fan-card
+entity: fan.air_purifier_4_pro
+integration: xiaomi_miot
+controls:
+  show_horizontal_swing: false
+  show_vertical_swing: false
+  show_horizontal_angle: false
+  show_vertical_angle: false
+  show_cycle: false
+  show_nudge: false
+details:
+  show_horizontal_angle: false
+  show_vertical_angle: false
+```
 
 ## Model coverage
 
@@ -61,6 +117,8 @@ Include:
 - Browser and frontend version
 - Integration name and fan model string
 - Redacted fan attributes and related entity domains and states
+- Related entity options, numeric ranges, units, and whether each entity
+  shares the primary fan device ID
 - Card configuration
 - Registered service name, if relevant
 - Console error and exact reproduction steps

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,7 @@ See the [README recipes](../README.md#recipes) for ready to paste layouts and
 
 ```yaml
 type: custom:xiaomi-fan-card
-entity: fan.xiaomi_smart_fan
+entity: fan.living_room_fan
 integration: auto
 layout:
   theme: mushroom
@@ -276,8 +276,8 @@ Fahrenheit sensor renders `°F` without extra configuration.
 The `controls.show_horizontal_*` and `controls.show_vertical_*` options are
 visibility switches, not capability overrides. Unsupported controls remain
 hidden even when a visibility switch is `true`. Set the switches to `false`
-for devices such as the Xiaomi Smart Air Purifier 4 Pro that expose presets
-but no actionable oscillation or angle entities.
+for a fan that reports presets but exposes no actionable oscillation or angle
+entity.
 
 The card reports its own size to Home Assistant. Masonry dashboards use
 `getCardSize`, and sections dashboards use `getGridOptions` with a

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -248,8 +248,8 @@ ignored for angle capabilities, so a generic mode selector cannot create a
 dead angle control.
 
 For Xiaomi MIOT, angle and vertical controls require an actionable related
-entity. A primary fan attribute can be displayed as state, but it does not
-authorize an angle action by itself. Vertical swing accepts `switch`,
+entity. A primary fan angle attribute alone is not displayed as a detail and
+does not authorize an angle action. Vertical swing accepts `switch`,
 `input_boolean`, or `select`; angle controls accept `number`, `input_number`,
 or numeric-option `select`.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,25 +86,39 @@ related_entities:
 | `force_sleep_mode_support` | none                 | Legacy alias for `show_sleep`.                                                             |
 | `hide_led_button`          | `false`              | Legacy option. Set to `true` to force `controls.show_led: false`.                          |
 
+## Integration action paths
+
+| `integration`     | Action path                                                                                    |
+| ----------------- | ---------------------------------------------------------------------------------------------- |
+| `auto`            | Standard Home Assistant fan actions and related entity discovery.                              |
+| `standard`        | Standard Home Assistant fan actions and related entity discovery.                              |
+| `xiaomi_miio`     | Standard fan actions plus related Xiaomi Home entities.                                        |
+| `xiaomi_miio_fan` | Standard fan actions plus registered `xiaomi_miio_fan.*` services for model-specific controls. |
+| `xiaomi_miot`     | Standard fan actions plus actionable related entities exposed by Xiaomi MIoT.                  |
+
+The card never calls a Xiaomi device directly. `auto` does not guess a vendor
+adapter. Select `xiaomi_miio_fan` only when the service registry contains the
+custom services required by the configured controls.
+
 ## Legacy top-level related-entity aliases
 
 These keys are still accepted for older YAML configurations. The nested
 `related_entities` values take precedence when both forms are present.
 
-| Parameter                 | Default   | Description                                                    |
-| ------------------------- | --------- | -------------------------------------------------------------- |
-| `horizontal_angle_entity` | automatic | Related horizontal angle `number` or `input_number` entity.    |
-| `vertical_swing_entity`   | automatic | Related vertical swing `switch`, `input_boolean`, or `select`. |
-| `vertical_angle_entity`   | automatic | Related vertical angle `number` or `input_number` entity.      |
-| `favorite_level_entity`   | automatic | Related favorite level `number` or `input_number` entity.      |
-| `sleep_mode_entity`       | automatic | Related sleep mode `switch`, `input_boolean`, or `select`.     |
-| `timer_entity`            | automatic | Related timer `number` or `input_number` entity.               |
-| `child_lock_entity`       | automatic | Related child lock `switch`, `input_boolean`, or `select`.     |
-| `led_entity`              | automatic | Related LED switch, select, or numeric entity.                 |
-| `buzzer_entity`           | automatic | Related buzzer `switch`, `input_boolean`, or `select`.         |
-| `ionizer_entity`          | automatic | Related ionizer `switch`, `input_boolean`, or `select`.        |
-| `temperature_entity`      | automatic | Related temperature `sensor` entity.                           |
-| `humidity_entity`         | automatic | Related humidity `sensor` entity.                              |
+| Parameter                 | Default   | Description                                                            |
+| ------------------------- | --------- | ---------------------------------------------------------------------- |
+| `horizontal_angle_entity` | automatic | Related horizontal angle `number`, `input_number`, or `select` entity. |
+| `vertical_swing_entity`   | automatic | Related vertical swing `switch`, `input_boolean`, or `select`.         |
+| `vertical_angle_entity`   | automatic | Related vertical angle `number`, `input_number`, or `select` entity.   |
+| `favorite_level_entity`   | automatic | Related favorite level `number` or `input_number` entity.              |
+| `sleep_mode_entity`       | automatic | Related sleep mode `switch`, `input_boolean`, or `select`.             |
+| `timer_entity`            | automatic | Related timer `number` or `input_number` entity.                       |
+| `child_lock_entity`       | automatic | Related child lock `switch`, `input_boolean`, or `select`.             |
+| `led_entity`              | automatic | Related LED switch, select, or numeric entity.                         |
+| `buzzer_entity`           | automatic | Related buzzer `switch`, `input_boolean`, or `select`.                 |
+| `ionizer_entity`          | automatic | Related ionizer `switch`, `input_boolean`, or `select`.                |
+| `temperature_entity`      | automatic | Related temperature `sensor` entity.                                   |
+| `humidity_entity`         | automatic | Related humidity `sensor` entity.                                      |
 
 ## `header`
 
@@ -205,20 +219,39 @@ Tokens compose with `layout.theme`: the theme sets the base design tokens and
 
 ## `related_entities`
 
-| Parameter                                  | Default   | Description                                                      |
-| ------------------------------------------ | --------- | ---------------------------------------------------------------- |
-| `related_entities.horizontal_angle_entity` | automatic | `number` or `input_number` for the horizontal angle.             |
-| `related_entities.vertical_swing_entity`   | automatic | `switch`, `input_boolean`, or `select` for vertical oscillation. |
-| `related_entities.vertical_angle_entity`   | automatic | `number` or `input_number` for the vertical angle.               |
-| `related_entities.favorite_level_entity`   | automatic | `number` or `input_number` for the favorite level.               |
-| `related_entities.sleep_mode_entity`       | automatic | `switch`, `input_boolean`, or `select` for sleep mode.           |
-| `related_entities.timer_entity`            | automatic | `number` or `input_number` for the timer.                        |
-| `related_entities.child_lock_entity`       | automatic | `switch`, `input_boolean`, or `select` for child lock.           |
-| `related_entities.led_entity`              | automatic | LED `switch`, `input_boolean`, `select`, or numeric entity.      |
-| `related_entities.buzzer_entity`           | automatic | `switch`, `input_boolean`, or `select` for the buzzer.           |
-| `related_entities.ionizer_entity`          | automatic | `switch`, `input_boolean`, or `select` for the ionizer.          |
-| `related_entities.temperature_entity`      | automatic | `sensor` for temperature.                                        |
-| `related_entities.humidity_entity`         | automatic | `sensor` for humidity.                                           |
+| Parameter                                  | Default   | Description                                                                          |
+| ------------------------------------------ | --------- | ------------------------------------------------------------------------------------ |
+| `related_entities.horizontal_angle_entity` | automatic | `number`, `input_number`, or `select` with numeric options for the horizontal angle. |
+| `related_entities.vertical_swing_entity`   | automatic | `switch`, `input_boolean`, or `select` for vertical oscillation.                     |
+| `related_entities.vertical_angle_entity`   | automatic | `number`, `input_number`, or `select` with numeric options for the vertical angle.   |
+| `related_entities.favorite_level_entity`   | automatic | `number` or `input_number` for the favorite level.                                   |
+| `related_entities.sleep_mode_entity`       | automatic | `switch`, `input_boolean`, or `select` for sleep mode.                               |
+| `related_entities.timer_entity`            | automatic | `number` or `input_number` for the timer.                                            |
+| `related_entities.child_lock_entity`       | automatic | `switch`, `input_boolean`, or `select` for child lock.                               |
+| `related_entities.led_entity`              | automatic | LED `switch`, `input_boolean`, `select`, or numeric entity.                          |
+| `related_entities.buzzer_entity`           | automatic | `switch`, `input_boolean`, or `select` for the buzzer.                               |
+| `related_entities.ionizer_entity`          | automatic | `switch`, `input_boolean`, or `select` for the ionizer.                              |
+| `related_entities.temperature_entity`      | automatic | `sensor` for temperature.                                                            |
+| `related_entities.humidity_entity`         | automatic | `sensor` for humidity.                                                               |
+
+Automatic related entity discovery uses the Home Assistant entity registry and
+matches entities sharing the primary fan `device_id`. It also matches known
+English and localized suffixes, including `_temperatuur` for temperature and
+`_luchtvochtigheid` for humidity. Use explicit related entity fields when an
+integration uses a different name or does not assign the entities to the same
+device.
+
+Angle `select` entities are supported when their options contain numeric
+values. Accepted examples include `0`, `30°`, `60 degrees`, `-10.5`, and `.5`.
+The optional degree suffix is case-insensitive. Non-numeric select options are
+ignored for angle capabilities, so a generic mode selector cannot create a
+dead angle control.
+
+For Xiaomi MIOT, angle and vertical controls require an actionable related
+entity. A primary fan attribute can be displayed as state, but it does not
+authorize an angle action by itself. Vertical swing accepts `switch`,
+`input_boolean`, or `select`; angle controls accept `number`, `input_number`,
+or numeric-option `select`.
 
 ## Behavior notes
 
@@ -237,6 +270,12 @@ cards and falls back below the graphic on narrow cards. Temperature and
 humidity details use the `unit_of_measurement` of the resolved sensor, so a
 Fahrenheit sensor renders `°F` without extra configuration.
 
+The `controls.show_horizontal_*` and `controls.show_vertical_*` options are
+visibility switches, not capability overrides. Unsupported controls remain
+hidden even when a visibility switch is `true`. Set the switches to `false`
+for devices such as the Xiaomi Smart Air Purifier 4 Pro that expose presets
+but no actionable oscillation or angle entities.
+
 The card reports its own size to Home Assistant. Masonry dashboards use
 `getCardSize`, and sections dashboards use `getGridOptions` with a
 twelve-column default whose row count follows the enabled header variant,
@@ -254,11 +293,19 @@ Timer controls use minutes. Related numeric timer entities with
 to and from minutes. Other or missing units are treated as minutes. The card
 preserves a live timer value that is not one of the configured steps.
 
+MIoT optional angle controls require discovered or configured related `select`,
+`number`, or `input_number` entities. Primary MIoT fan attributes alone are
+not treated as angle actions. The `controls.show_horizontal_*` and
+`controls.show_vertical_*` options are visibility switches, not capability
+overrides. For the issue #26 purifier case, disable unsupported horizontal or
+vertical controls explicitly.
+
 For Xiaomi LED brightness controls, the custom Xiaomi service contract is
 `0` for bright, `1` for dim, and `2` for off. A related
 `*_led_brightness` number with a `0..2` range uses the same mapping. Other
-switch, select, and number entities use their exposed Home Assistant
-contract.
+switch, semantic select, and number entities use their exposed Home Assistant
+contract. Numeric LED brightness select options use the same `0`/`1`/`2`
+mapping.
 
 ## Configuration compatibility
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -235,17 +235,20 @@ Tokens compose with `layout.theme`: the theme sets the base design tokens and
 | `related_entities.humidity_entity`         | automatic | `sensor` for humidity.                                                               |
 
 Automatic related entity discovery uses the Home Assistant entity registry and
-matches entities sharing the primary fan `device_id`. It also matches known
-English and localized suffixes, including `_temperatuur` for temperature and
-`_luchtvochtigheid` for humidity. Use explicit related entity fields when an
-integration uses a different name or does not assign the entities to the same
-device.
+matches entities sharing the primary fan `device_id` by entity name. Temperature
+and humidity resolve from the sensor `device_class` first, so a translated Home
+Assistant install works without an English entity name. Use explicit related
+entity fields when an integration uses a different name or does not assign the
+entities to the same device.
 
 Angle `select` entities are supported when their options contain numeric
-values. Accepted examples include `0`, `30°`, `60 degrees`, `-10.5`, and `.5`.
-The optional degree suffix is case-insensitive. Non-numeric select options are
-ignored for angle capabilities, so a generic mode selector cannot create a
-dead angle control.
+values, written as `30`, `30°`, or `30 degrees`. Non-numeric select options are
+ignored for angle capabilities, so a generic mode selector cannot create a dead
+angle control or overwrite an angle reported by the fan entity.
+
+Angle `number` and `input_number` entities use their own `min`, `max`, and
+`step`. A range short enough for a dropdown becomes a preset list, and a wider
+range keeps a numeric input bounded by the same values.
 
 For Xiaomi MIOT, angle and vertical controls require an actionable related
 entity. A primary fan angle attribute alone is not displayed as a detail and
@@ -295,17 +298,15 @@ preserves a live timer value that is not one of the configured steps.
 
 MIoT optional angle controls require discovered or configured related `select`,
 `number`, or `input_number` entities. Primary MIoT fan attributes alone are
-not treated as angle actions. The `controls.show_horizontal_*` and
-`controls.show_vertical_*` options are visibility switches, not capability
-overrides. For the issue #26 purifier case, disable unsupported horizontal or
-vertical controls explicitly.
+not treated as angle actions.
 
 For Xiaomi LED brightness controls, the custom Xiaomi service contract is
 `0` for bright, `1` for dim, and `2` for off. A related
-`*_led_brightness` number with a `0..2` range uses the same mapping. Other
-switch, semantic select, and number entities use their exposed Home Assistant
-contract. Numeric LED brightness select options use the same `0`/`1`/`2`
-mapping.
+`*_led_brightness` number with a `0..2` range uses the same mapping, and
+numeric LED brightness select options use it as well. A named LED select is
+matched on its labels: turning the LED off picks an explicit off option rather
+than a dim option, and a dimmed LED still reads as on. Switch and plain number
+entities use their exposed Home Assistant contract.
 
 ## Configuration compatibility
 

--- a/src/adapters/standard-fan.ts
+++ b/src/adapters/standard-fan.ts
@@ -26,15 +26,19 @@ const numericOptionValue = (value: unknown): number | undefined => {
   return match ? Number(match[1]) : undefined;
 };
 
-const numericAngleOptions = (entity: HassEntity | undefined): number[] | undefined => {
-  const options = entity?.attributes["options"];
+const numericOptions = (options: unknown): number[] | undefined => {
   if (!Array.isArray(options)) {
     return undefined;
   }
 
-  const angles = [...new Set(options.map(numericOptionValue).filter((value): value is number => value !== undefined))];
+  const angles = [
+    ...new Set(options.map(numericOptionValue).filter((value): value is number => value !== undefined)),
+  ].sort((left, right) => left - right);
   return angles.length > 0 ? angles : undefined;
 };
+
+const numericAngleOptions = (entity: HassEntity | undefined): number[] | undefined =>
+  numericOptions(entity?.attributes["options"]);
 
 export class StandardFanAdapter implements FanAdapter {
   public readonly state: NormalizedFanState;
@@ -160,15 +164,18 @@ export class StandardFanAdapter implements FanAdapter {
     for (const [relatedKey, attributeKey] of relatedValues) {
       const relatedEntityId = related[relatedKey];
       const relatedState = relatedEntityId ? this.hass.states[relatedEntityId] : undefined;
-      if (relatedState && relatedState.state !== "unknown" && relatedState.state !== "unavailable") {
+      if (relatedEntityId && relatedState && relatedState.state !== "unknown" && relatedState.state !== "unavailable") {
+        if (relatedKey === "led") {
+          attributes[attributeKey] = this.readRelatedLedState(relatedEntityId, relatedState);
+          delete attributes["led_brightness"];
+          continue;
+        }
+
         const value = Number(relatedState.state);
         attributes[attributeKey] =
           relatedKey === "timer" && Number.isFinite(value) && timerSpec
             ? timerValueToMinutes(value, timerSpec.unit)
             : relatedState.state;
-        if (relatedKey === "led") {
-          attributes["led_brightness"] = relatedState.state;
-        }
       } else if (relatedState) {
         delete attributes[attributeKey];
         if (relatedKey === "led") {
@@ -180,6 +187,32 @@ export class StandardFanAdapter implements FanAdapter {
     }
 
     return { ...entity, attributes };
+  }
+
+  private readRelatedLedState(entityId: string, entity: HassEntity): string | boolean {
+    const [domain] = entityParts(entityId);
+    const current = numericOptionValue(entity.state);
+
+    if (domain === "number" || domain === "input_number") {
+      const minimum = Number(entity.attributes["min"]);
+      const maximum = Number(entity.attributes["max"]);
+      if (current !== undefined && Number.isFinite(minimum) && Number.isFinite(maximum) && maximum >= minimum) {
+        return this.isCustomLedBrightnessMapping(entityId, minimum, maximum) ? current < 2 : current > minimum;
+      }
+    }
+
+    if (domain === "select") {
+      const options = numericOptions(entity.attributes["options"]) ?? [];
+      if (current !== undefined && options.includes(0) && options.includes(2)) {
+        return current < 2;
+      }
+    }
+
+    return entity.state;
+  }
+
+  private isCustomLedBrightnessMapping(entityId: string, minimum: number, maximum: number): boolean {
+    return entityId.endsWith("_led_brightness") && minimum === 0 && maximum === 2;
   }
 
   public async togglePower(): Promise<void> {
@@ -526,7 +559,7 @@ export class StandardFanAdapter implements FanAdapter {
       return false;
     }
 
-    const customBrightnessMapping = entityId.endsWith("_led_brightness") && minimum === 0 && maximum === 2;
+    const customBrightnessMapping = this.isCustomLedBrightnessMapping(entityId, minimum, maximum);
     await this.hass.callService(domain, "set_value", {
       entity_id: entityId,
       value: enabled ? (customBrightnessMapping ? minimum : maximum) : customBrightnessMapping ? maximum : minimum,

--- a/src/adapters/standard-fan.ts
+++ b/src/adapters/standard-fan.ts
@@ -1,6 +1,12 @@
 import { detectCapabilities } from "../state/capabilities";
 import { getModelProfile } from "../state/model-profiles";
-import { minutesToTimerValue, normalizeFanState, parseTimerUnit, timerValueToMinutes } from "../state/normalize-state";
+import {
+  minutesToTimerValue,
+  normalizeFanState,
+  numericLabel,
+  parseTimerUnit,
+  timerValueToMinutes,
+} from "../state/normalize-state";
 import { ServiceDispatcher } from "../services/service-dispatcher";
 import type {
   FanAdapter,
@@ -10,20 +16,23 @@ import type {
   HassEntity,
   HassLike,
   NormalizedFanState,
+  NumberSpec,
   RelatedEntities,
   ServiceAvailability,
   TimerSpec,
 } from "../types";
 
+/**
+ * A dropdown turns unusable well before a fine-grained angle entity runs out of
+ * steps, so a wider range reports its raw spec instead of a preset list.
+ */
+const MAX_ANGLE_STEPS = 24;
+
+const MAX_TIMER_STEPS = 100;
+
 const entityParts = (entityId: string): [string, string] => {
   const [domain, objectId] = entityId.split(".");
   return [domain ?? "", objectId ?? ""];
-};
-
-const numericOptionValue = (value: unknown): number | undefined => {
-  const text = typeof value === "string" || typeof value === "number" ? String(value).trim() : "";
-  const match = text.match(/^([+-]?(?:\d+(?:\.\d+)?|\.\d+))\s*(?:°|degrees?)?$/i);
-  return match ? Number(match[1]) : undefined;
 };
 
 const numericOptions = (options: unknown): number[] | undefined => {
@@ -31,14 +40,64 @@ const numericOptions = (options: unknown): number[] | undefined => {
     return undefined;
   }
 
-  const angles = [
-    ...new Set(options.map(numericOptionValue).filter((value): value is number => value !== undefined)),
-  ].sort((left, right) => left - right);
+  const angles = [...new Set(options.map(numericLabel).filter((value): value is number => value !== undefined))].sort(
+    (left, right) => left - right,
+  );
   return angles.length > 0 ? angles : undefined;
 };
 
 const numericAngleOptions = (entity: HassEntity | undefined): number[] | undefined =>
   numericOptions(entity?.attributes["options"]);
+
+const selectOptions = (entity: HassEntity | undefined): string[] => {
+  const options = entity?.attributes["options"];
+  return Array.isArray(options) ? options.map(String) : [];
+};
+
+/**
+ * Exact labels win over substring hints because a substring search returns the
+ * first matching option rather than the closest one: `Dim` would answer a
+ * request for `Off`, and `on` hides inside words such as `None`.
+ */
+const selectOptionFor = (options: string[], exact: readonly string[], hints: readonly string[]): string | undefined => {
+  const normalized = options.map((option) => ({ option, key: option.trim().toLowerCase() }));
+
+  for (const label of exact) {
+    const match = normalized.find((entry) => entry.key === label);
+    if (match) {
+      return match.option;
+    }
+  }
+
+  for (const hint of hints) {
+    const match = normalized.find((entry) => entry.key.includes(hint));
+    if (match) {
+      return match.option;
+    }
+  }
+
+  return undefined;
+};
+
+const rawSteps = (spec: NumberSpec): number[] =>
+  Array.from({ length: Math.floor((spec.max - spec.min) / spec.step) + 1 }, (_, index) => spec.min + index * spec.step);
+
+const roundStep = (value: number): number => Math.round(value * 100) / 100;
+
+const BOOLEAN_SELECT_LABELS = {
+  enabledExact: ["on", "true", "yes", "enable", "enabled"],
+  enabledHints: ["bright", "enable", "active", "sleep", "oscillate", "swing", "true"],
+  disabledExact: ["off", "false", "no", "disable", "disabled"],
+  disabledHints: ["off", "disable", "inactive", "false", "none", "normal", "fixed", "static", "dim"],
+} as const;
+
+const isDisabledLabel = (value: string): boolean =>
+  selectOptionFor([value], BOOLEAN_SELECT_LABELS.disabledExact, ["off", "disable", "inactive"]) !== undefined;
+
+const booleanSelectOption = (options: string[], enabled: boolean): string | undefined =>
+  enabled
+    ? selectOptionFor(options, BOOLEAN_SELECT_LABELS.enabledExact, BOOLEAN_SELECT_LABELS.enabledHints)
+    : selectOptionFor(options, BOOLEAN_SELECT_LABELS.disabledExact, BOOLEAN_SELECT_LABELS.disabledHints);
 
 export class StandardFanAdapter implements FanAdapter {
   public readonly state: NormalizedFanState;
@@ -64,12 +123,14 @@ export class StandardFanAdapter implements FanAdapter {
         this.readAngleOptions(actionableRelated.horizontalAngle) ??
         (detectedCapabilities.horizontalAngles.length > 0
           ? detectedCapabilities.horizontalAngles
-          : (this.readNumberSteps(this.readTimerSpec(actionableRelated.horizontalAngle)) ?? [])),
+          : (this.readAngleSteps(actionableRelated.horizontalAngle) ?? [])),
+      horizontalAngleSpec: this.readNumberSpec(actionableRelated.horizontalAngle),
       verticalAngles:
         this.readAngleOptions(actionableRelated.verticalAngle) ??
         (detectedCapabilities.verticalAngles.length > 0
           ? detectedCapabilities.verticalAngles
-          : (this.readNumberSteps(this.readTimerSpec(actionableRelated.verticalAngle)) ?? [])),
+          : (this.readAngleSteps(actionableRelated.verticalAngle) ?? [])),
+      verticalAngleSpec: this.readNumberSpec(actionableRelated.verticalAngle),
       timerSteps: this.readNumberSteps(actionableRelated.timer ? timerSpec : undefined),
       timerSpec: actionableRelated.timer ? timerSpec : undefined,
     };
@@ -105,24 +166,46 @@ export class StandardFanAdapter implements FanAdapter {
     return numericAngleOptions(entityId ? this.hass.states[entityId] : undefined);
   }
 
-  private readTimerSpec(entityId: string | undefined): TimerSpec | undefined {
-    const timerEntity = entityId ? this.hass.states[entityId] : undefined;
-    const minimum = Number(timerEntity?.attributes["min"]);
-    const maximum = Number(timerEntity?.attributes["max"]);
-    const step = Number(timerEntity?.attributes["step"]);
+  private readNumberSpec(entityId: string | undefined): NumberSpec | undefined {
+    const entity = entityId ? this.hass.states[entityId] : undefined;
+    const minimum = Number(entity?.attributes["min"]);
+    const maximum = Number(entity?.attributes["max"]);
+    const step = Number(entity?.attributes["step"]);
     if (
       !Number.isFinite(minimum) ||
       !Number.isFinite(maximum) ||
       !Number.isFinite(step) ||
       step <= 0 ||
-      maximum < minimum ||
-      (maximum - minimum) / step > 100
+      maximum < minimum
     ) {
       return undefined;
     }
 
-    const unit = parseTimerUnit(timerEntity?.attributes["unit_of_measurement"]);
-    return { unit, min: minimum, max: maximum, step };
+    return { min: minimum, max: maximum, step };
+  }
+
+  private readTimerSpec(entityId: string | undefined): TimerSpec | undefined {
+    const spec = this.readNumberSpec(entityId);
+    if (!spec || (spec.max - spec.min) / spec.step > MAX_TIMER_STEPS) {
+      return undefined;
+    }
+
+    const entity = entityId ? this.hass.states[entityId] : undefined;
+    return { ...spec, unit: parseTimerUnit(entity?.attributes["unit_of_measurement"]) };
+  }
+
+  /**
+   * Angles carry no timer unit, so they never go through the timer conversion.
+   * A range too wide for a dropdown reports no presets and leaves the card on
+   * the bounded numeric input built from the same spec.
+   */
+  private readAngleSteps(entityId: string | undefined): number[] | undefined {
+    const spec = this.readNumberSpec(entityId);
+    if (!spec || (spec.max - spec.min) / spec.step > MAX_ANGLE_STEPS) {
+      return undefined;
+    }
+
+    return rawSteps(spec).map(roundStep);
   }
 
   private readNumberSteps(spec: TimerSpec | undefined): number[] | undefined {
@@ -130,10 +213,7 @@ export class StandardFanAdapter implements FanAdapter {
       return undefined;
     }
 
-    return Array.from(
-      { length: Math.floor((spec.max - spec.min) / spec.step) + 1 },
-      (_, index) => Math.round(timerValueToMinutes(spec.min + index * spec.step, spec.unit) * 100) / 100,
-    );
+    return rawSteps(spec).map((value) => roundStep(timerValueToMinutes(value, spec.unit)));
   }
 
   private entityWithRelatedAttributes(
@@ -171,6 +251,15 @@ export class StandardFanAdapter implements FanAdapter {
           continue;
         }
 
+        // A mode selector matched as an angle entity carries no angle, so the
+        // primary attribute stays authoritative instead of being overwritten.
+        if (
+          (relatedKey === "horizontalAngle" || relatedKey === "verticalAngle") &&
+          numericLabel(relatedState.state) === undefined
+        ) {
+          continue;
+        }
+
         const value = Number(relatedState.state);
         attributes[attributeKey] =
           relatedKey === "timer" && Number.isFinite(value) && timerSpec
@@ -191,7 +280,7 @@ export class StandardFanAdapter implements FanAdapter {
 
   private readRelatedLedState(entityId: string, entity: HassEntity): string | boolean {
     const [domain] = entityParts(entityId);
-    const current = numericOptionValue(entity.state);
+    const current = numericLabel(entity.state);
 
     if (domain === "number" || domain === "input_number") {
       const minimum = Number(entity.attributes["min"]);
@@ -206,6 +295,9 @@ export class StandardFanAdapter implements FanAdapter {
       if (current !== undefined && options.includes(0) && options.includes(2)) {
         return current < 2;
       }
+
+      // A dimmed LED is still lit, so only an explicit off label reads as off.
+      return !isDisabledLabel(entity.state);
     }
 
     return entity.state;
@@ -447,19 +539,14 @@ export class StandardFanAdapter implements FanAdapter {
       return false;
     }
 
-    const options = state.attributes["options"];
-    if (!Array.isArray(options)) {
-      return false;
-    }
-
-    const option = options.find((candidate) => numericOptionValue(candidate) === angle);
+    const option = selectOptions(state).find((candidate) => numericLabel(candidate) === angle);
     if (option === undefined) {
       return false;
     }
 
     await this.hass.callService("select", "select_option", {
       entity_id: entityId,
-      option: typeof option === "string" || typeof option === "number" ? String(option) : option,
+      option,
     });
     return true;
   }
@@ -481,23 +568,16 @@ export class StandardFanAdapter implements FanAdapter {
     }
 
     if (domain === "select") {
-      const options = this.hass.states[entityId]?.attributes["options"];
-      const availableOptions = Array.isArray(options) ? options.map(String) : [];
-      const enabledOptions = ["on", "true", "enable", "sleep", "bright", "active", "oscillate", "swing"];
-      const disabledOptions = ["off", "false", "disable", "normal", "none", "dim", "fixed", "static"];
-      const option = enabled
-        ? (availableOptions.find((candidate) =>
-            enabledOptions.some((token) => candidate.toLowerCase().includes(token)),
-          ) ?? "on")
-        : (availableOptions.find((candidate) =>
-            disabledOptions.some((token) => candidate.toLowerCase().includes(token)),
-          ) ?? "off");
+      const availableOptions = selectOptions(state);
       if (availableOptions.length === 0) {
         throw new Error(`Related select ${entityId} has no valid options.`);
       }
-      if (!availableOptions.includes(option)) {
+
+      const option = booleanSelectOption(availableOptions, enabled);
+      if (option === undefined) {
         throw new Error(`Related select ${entityId} has no matching boolean option.`);
       }
+
       await this.hass.callService(domain, "select_option", {
         entity_id: entityId,
         option,
@@ -520,17 +600,11 @@ export class StandardFanAdapter implements FanAdapter {
     }
 
     if (domain === "select") {
-      const options = state.attributes["options"];
-      const availableOptions = Array.isArray(options) ? options.map(String) : [];
+      const availableOptions = selectOptions(state);
       const numericTarget = enabled ? 0 : 2;
       const option =
-        availableOptions.find((candidate) => numericOptionValue(candidate) === numericTarget) ??
-        availableOptions.find((candidate) =>
-          (enabled
-            ? ["on", "true", "enable", "bright", "active"]
-            : ["off", "false", "disable", "dim", "inactive"]
-          ).some((token) => candidate.toLowerCase().includes(token)),
-        );
+        availableOptions.find((candidate) => numericLabel(candidate) === numericTarget) ??
+        booleanSelectOption(availableOptions, enabled);
       if (option === undefined) {
         return false;
       }

--- a/src/adapters/standard-fan.ts
+++ b/src/adapters/standard-fan.ts
@@ -20,6 +20,22 @@ const entityParts = (entityId: string): [string, string] => {
   return [domain ?? "", objectId ?? ""];
 };
 
+const numericOptionValue = (value: unknown): number | undefined => {
+  const text = typeof value === "string" || typeof value === "number" ? String(value).trim() : "";
+  const match = text.match(/^([+-]?(?:\d+(?:\.\d+)?|\.\d+))\s*(?:°|degrees?)?$/i);
+  return match ? Number(match[1]) : undefined;
+};
+
+const numericAngleOptions = (entity: HassEntity | undefined): number[] | undefined => {
+  const options = entity?.attributes["options"];
+  if (!Array.isArray(options)) {
+    return undefined;
+  }
+
+  const angles = [...new Set(options.map(numericOptionValue).filter((value): value is number => value !== undefined))];
+  return angles.length > 0 ? angles : undefined;
+};
+
 export class StandardFanAdapter implements FanAdapter {
   public readonly state: NormalizedFanState;
   public readonly profile: FanModelProfile;
@@ -41,13 +57,15 @@ export class StandardFanAdapter implements FanAdapter {
     this.capabilities = {
       ...detectedCapabilities,
       horizontalAngles:
-        detectedCapabilities.horizontalAngles.length > 0
+        this.readAngleOptions(actionableRelated.horizontalAngle) ??
+        (detectedCapabilities.horizontalAngles.length > 0
           ? detectedCapabilities.horizontalAngles
-          : (this.readNumberSteps(this.readTimerSpec(actionableRelated.horizontalAngle)) ?? []),
+          : (this.readNumberSteps(this.readTimerSpec(actionableRelated.horizontalAngle)) ?? [])),
       verticalAngles:
-        detectedCapabilities.verticalAngles.length > 0
+        this.readAngleOptions(actionableRelated.verticalAngle) ??
+        (detectedCapabilities.verticalAngles.length > 0
           ? detectedCapabilities.verticalAngles
-          : (this.readNumberSteps(this.readTimerSpec(actionableRelated.verticalAngle)) ?? []),
+          : (this.readNumberSteps(this.readTimerSpec(actionableRelated.verticalAngle)) ?? [])),
       timerSteps: this.readNumberSteps(actionableRelated.timer ? timerSpec : undefined),
       timerSpec: actionableRelated.timer ? timerSpec : undefined,
     };
@@ -60,12 +78,27 @@ export class StandardFanAdapter implements FanAdapter {
     for (const key of Object.keys(actionable) as Array<keyof RelatedEntities>) {
       const entityId = actionable[key];
       const state = entityId ? this.hass.states[entityId] : undefined;
-      if (!state || state.state === "unknown" || state.state === "unavailable") {
+      if (
+        !state ||
+        state.state === "unknown" ||
+        state.state === "unavailable" ||
+        ((key === "horizontalAngle" || key === "verticalAngle") &&
+          this.isSelectEntity(entityId) &&
+          numericAngleOptions(state) === undefined)
+      ) {
         delete actionable[key];
       }
     }
 
     return actionable;
+  }
+
+  private isSelectEntity(entityId: string | undefined): boolean {
+    return entityId !== undefined && entityParts(entityId)[0] === "select";
+  }
+
+  private readAngleOptions(entityId: string | undefined): number[] | undefined {
+    return numericAngleOptions(entityId ? this.hass.states[entityId] : undefined);
   }
 
   private readTimerSpec(entityId: string | undefined): TimerSpec | undefined {
@@ -228,7 +261,7 @@ export class StandardFanAdapter implements FanAdapter {
   public async setHorizontalAngle(angle: number): Promise<void> {
     await this.startSwing("horizontal");
 
-    if (await this.setRelatedValue(this.related.horizontalAngle, angle)) {
+    if (await this.setRelatedAngle(this.related.horizontalAngle, angle)) {
       return;
     }
 
@@ -246,7 +279,7 @@ export class StandardFanAdapter implements FanAdapter {
   public async setVerticalAngle(angle: number): Promise<void> {
     await this.startSwing("vertical");
 
-    if (await this.setRelatedValue(this.related.verticalAngle, angle)) {
+    if (await this.setRelatedAngle(this.related.verticalAngle, angle)) {
       return;
     }
 
@@ -310,11 +343,11 @@ export class StandardFanAdapter implements FanAdapter {
   }
 
   public async setLed(enabled: boolean): Promise<void> {
-    if (await this.setRelatedBoolean(this.related.led, enabled)) {
+    if (await this.setRelatedLedBrightness(this.related.led, enabled)) {
       return;
     }
 
-    if (await this.setRelatedLedBrightness(this.related.led, enabled)) {
+    if (await this.setRelatedBoolean(this.related.led, enabled)) {
       return;
     }
 
@@ -359,6 +392,42 @@ export class StandardFanAdapter implements FanAdapter {
     }
 
     await this.hass.callService(domain, "set_value", { entity_id: entityId, value });
+    return true;
+  }
+
+  private async setRelatedAngle(entityId: string | undefined, angle: number): Promise<boolean> {
+    if (!entityId) {
+      return false;
+    }
+
+    const state = this.hass.states[entityId];
+    if (!state || state.state === "unknown" || state.state === "unavailable") {
+      return false;
+    }
+
+    const [domain] = entityParts(entityId);
+    if (domain === "number" || domain === "input_number") {
+      return this.setRelatedValue(entityId, angle);
+    }
+
+    if (domain !== "select") {
+      return false;
+    }
+
+    const options = state.attributes["options"];
+    if (!Array.isArray(options)) {
+      return false;
+    }
+
+    const option = options.find((candidate) => numericOptionValue(candidate) === angle);
+    if (option === undefined) {
+      return false;
+    }
+
+    await this.hass.callService("select", "select_option", {
+      entity_id: entityId,
+      option: typeof option === "string" || typeof option === "number" ? String(option) : option,
+    });
     return true;
   }
 
@@ -412,11 +481,38 @@ export class StandardFanAdapter implements FanAdapter {
     }
 
     const [domain] = entityParts(entityId);
+    const state = this.hass.states[entityId];
+    if (!state || state.state === "unknown" || state.state === "unavailable") {
+      return false;
+    }
+
+    if (domain === "select") {
+      const options = state.attributes["options"];
+      const availableOptions = Array.isArray(options) ? options.map(String) : [];
+      const numericTarget = enabled ? 0 : 2;
+      const option =
+        availableOptions.find((candidate) => numericOptionValue(candidate) === numericTarget) ??
+        availableOptions.find((candidate) =>
+          (enabled
+            ? ["on", "true", "enable", "bright", "active"]
+            : ["off", "false", "disable", "dim", "inactive"]
+          ).some((token) => candidate.toLowerCase().includes(token)),
+        );
+      if (option === undefined) {
+        return false;
+      }
+
+      await this.hass.callService("select", "select_option", {
+        entity_id: entityId,
+        option,
+      });
+      return true;
+    }
+
     if (domain !== "number" && domain !== "input_number") {
       return false;
     }
 
-    const state = this.hass.states[entityId];
     const minimum = Number(state?.attributes["min"]);
     const maximum = Number(state?.attributes["max"]);
     if (

--- a/src/card.ts
+++ b/src/card.ts
@@ -12,6 +12,7 @@ import { DEFAULT_CONFIG, normalizeCardConfig } from "./config";
 import "./editor";
 import { getConfigForm } from "./editor-schema";
 import { loadServiceAvailability } from "./services/service-dispatcher";
+import { numericLabel } from "./state/normalize-state";
 import { resolveRelatedEntities } from "./state/related-entities";
 import { getAirflowAxis } from "./state/visual-state";
 import { createTranslator, type TranslationKey, type TranslationValues, type Translator } from "./translations";
@@ -20,6 +21,7 @@ import type {
   FanCardConfig,
   FanBlock,
   HassLike,
+  NumberSpec,
   RelatedEntities,
   ResolvedFanCardConfig,
   ServiceAvailability,
@@ -346,12 +348,7 @@ export class XiaomiFanCard extends LitElement {
         ? (this.config.horizontal_angle_entity ?? this.related.horizontalAngle)
         : (this.config.vertical_angle_entity ?? this.related.verticalAngle);
     const raw = entityId ? this.hass?.states[entityId]?.state : undefined;
-    if (typeof raw !== "string" || raw.trim() === "") {
-      return fallback;
-    }
-
-    const value = Number(raw);
-    return Number.isFinite(value) ? value : fallback;
+    return numericLabel(raw) ?? fallback;
   }
 
   private withConfiguredRelatedEntities(discovered: RelatedEntities): RelatedEntities {
@@ -889,8 +886,12 @@ export class XiaomiFanCard extends LitElement {
               (angle) => this.execute(() => adapter.setHorizontalAngle(angle)),
               "mdi:arrow-left-right",
             )
-          : this.renderAngleControl(this.t("horizontalAngle"), horizontalAngle, angles, (angle) =>
-              this.execute(() => adapter.setHorizontalAngle(angle)),
+          : this.renderAngleControl(
+              this.t("horizontalAngle"),
+              horizontalAngle,
+              angles,
+              (angle) => this.execute(() => adapter.setHorizontalAngle(angle)),
+              adapter.capabilities.horizontalAngleSpec,
             ),
       );
     }
@@ -906,8 +907,12 @@ export class XiaomiFanCard extends LitElement {
               (angle) => this.execute(() => adapter.setVerticalAngle(angle)),
               "mdi:swap-vertical",
             )
-          : this.renderAngleControl(this.t("verticalAngle"), verticalAngle, angles, (angle) =>
-              this.execute(() => adapter.setVerticalAngle(angle)),
+          : this.renderAngleControl(
+              this.t("verticalAngle"),
+              verticalAngle,
+              angles,
+              (angle) => this.execute(() => adapter.setVerticalAngle(angle)),
+              adapter.capabilities.verticalAngleSpec,
             ),
       );
     }
@@ -1136,8 +1141,9 @@ export class XiaomiFanCard extends LitElement {
     value: number | undefined,
     angles: number[],
     onChange: (angle: number) => void,
+    spec?: NumberSpec,
   ) {
-    const current = value ?? angles[0] ?? 0;
+    const current = value ?? angles[0] ?? spec?.min ?? 0;
     const options = angles.includes(current) ? angles : [...angles, current].sort((left, right) => left - right);
     return html`
       <label class="feature-select">
@@ -1158,9 +1164,9 @@ export class XiaomiFanCard extends LitElement {
             : html`
                 <input
                   type="number"
-                  min="0"
-                  max="360"
-                  step="1"
+                  min=${spec?.min ?? 0}
+                  max=${spec?.max ?? 360}
+                  step=${spec?.step ?? 1}
                   .value=${String(current)}
                   @change=${(event: Event) => onChange(Number((event.currentTarget as HTMLInputElement).value))}
                   aria-label=${label}

--- a/src/state/capabilities.ts
+++ b/src/state/capabilities.ts
@@ -1,6 +1,9 @@
 import { getModelProfile, isXiaomiFanModel, resolveSpeedLevels } from "./model-profiles";
 import type { FanCapabilities, HassEntity, RelatedEntities, ServiceAvailability } from "../types";
 
+const FAN_FEATURE_OSCILLATE = 2;
+const FAN_FEATURE_DIRECTION = 4;
+
 const hasAttribute = (entity: HassEntity | undefined, keys: string[]): boolean =>
   entity !== undefined && keys.some((key) => Object.prototype.hasOwnProperty.call(entity.attributes, key));
 
@@ -61,13 +64,13 @@ export const detectCapabilities = (
     speedLevels: resolveSpeedLevels(entity?.attributes ?? {}, profile),
     direction:
       hasAttribute(entity, ["direction", "current_direction"]) ||
-      hasFanFeature(entity, 16) ||
+      hasFanFeature(entity, FAN_FEATURE_DIRECTION) ||
       hasService(services, "fan.set_direction"),
     sleepMode: Boolean(related.sleepMode) || hasSleepPreset,
     favoriteLevel: Boolean(related.favoriteLevel),
     horizontalSwing:
       hasAttribute(entity, ["oscillating", "oscillate", "horizontal_swing", "swing_mode"]) ||
-      hasFanFeature(entity, 8) ||
+      hasFanFeature(entity, FAN_FEATURE_OSCILLATE) ||
       (profile.known && profile.isXiaomi && profile.model !== "xiaomi.fan.2lite"),
     horizontalAngle:
       Boolean(related.horizontalAngle) ||

--- a/src/state/normalize-state.ts
+++ b/src/state/normalize-state.ts
@@ -30,7 +30,11 @@ const numberValue = (value: unknown): number | undefined => {
   return undefined;
 };
 
-const angleValue = (value: unknown): number | undefined => {
+/**
+ * Integrations expose numbers bare or wrapped in a unit label such as `90°`
+ * and `60 degrees`, which is how select options usually arrive.
+ */
+export const numericLabel = (value: unknown): number | undefined => {
   const numeric = numberValue(value);
   if (numeric !== undefined) {
     return numeric;
@@ -100,7 +104,7 @@ const firstNumber = (attributes: Record<string, unknown>, keys: string[]): numbe
 
 const firstAngle = (attributes: Record<string, unknown>, keys: string[]): number | undefined => {
   for (const key of keys) {
-    const value = angleValue(attributes[key]);
+    const value = numericLabel(attributes[key]);
     if (value !== undefined) {
       return value;
     }

--- a/src/state/normalize-state.ts
+++ b/src/state/normalize-state.ts
@@ -30,6 +30,20 @@ const numberValue = (value: unknown): number | undefined => {
   return undefined;
 };
 
+const angleValue = (value: unknown): number | undefined => {
+  const numeric = numberValue(value);
+  if (numeric !== undefined) {
+    return numeric;
+  }
+
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const match = value.trim().match(/^([+-]?(?:\d+(?:\.\d+)?|\.\d+))\s*(?:°|degrees?)?$/i);
+  return match ? Number(match[1]) : undefined;
+};
+
 const booleanValue = (value: unknown): boolean | undefined => {
   if (typeof value === "boolean") {
     return value;
@@ -84,6 +98,17 @@ const firstNumber = (attributes: Record<string, unknown>, keys: string[]): numbe
   return undefined;
 };
 
+const firstAngle = (attributes: Record<string, unknown>, keys: string[]): number | undefined => {
+  for (const key of keys) {
+    const value = angleValue(attributes[key]);
+    if (value !== undefined) {
+      return value;
+    }
+  }
+
+  return undefined;
+};
+
 const firstBoolean = (attributes: Record<string, unknown>, keys: string[]): boolean | undefined => {
   for (const key of keys) {
     const value = booleanValue(attributes[key]);
@@ -106,13 +131,18 @@ const timerMinutes = (attributes: Record<string, unknown>): number | undefined =
 };
 
 const ledState = (attributes: Record<string, unknown>): boolean | undefined => {
+  const brightness = firstNumber(attributes, ["led_brightness"]);
+  if (brightness !== undefined) {
+    return brightness < 2;
+  }
+
   const direct = firstBoolean(attributes, ["led", "light", "light_enum"]);
   if (direct !== undefined) {
     return direct;
   }
 
-  const brightness = firstNumber(attributes, ["led_brightness", "light", "led"]);
-  return brightness === undefined ? undefined : brightness < 2;
+  const fallbackBrightness = firstNumber(attributes, ["light", "led"]);
+  return fallbackBrightness === undefined ? undefined : fallbackBrightness < 2;
 };
 
 const readPresetModes = (...values: unknown[]): string[] => {
@@ -161,14 +191,14 @@ export const normalizeFanState = (entityId: string, entity?: HassEntity): Normal
     sleepMode,
     direction: directionValue === "forward" || directionValue === "reverse" ? directionValue : undefined,
     horizontalSwing: firstBoolean(attributes, ["oscillating", "oscillate", "horizontal_swing", "swing_mode"]),
-    horizontalAngle: firstNumber(attributes, [
+    horizontalAngle: firstAngle(attributes, [
       "horizontal_swing_angle",
       "horizontal_angle",
       "swing_mode_angle",
       "angle",
     ]),
     verticalSwing: firstBoolean(attributes, ["vertical_swing", "vertical_oscillate", "vertical_oscillation"]),
-    verticalAngle: firstNumber(attributes, ["vertical_swing_angle", "vertical_oscillation_angle", "vertical_angle"]),
+    verticalAngle: firstAngle(attributes, ["vertical_swing_angle", "vertical_oscillation_angle", "vertical_angle"]),
     timerMinutes: timerMinutes(attributes),
     childLock: booleanValue(attributes["child_lock"]),
     led: ledState(attributes),

--- a/src/state/related-entities.ts
+++ b/src/state/related-entities.ts
@@ -18,8 +18,8 @@ const suffixes: Record<keyof RelatedEntities, string[]> = {
   led: ["_led", "_led_brightness", "_light"],
   buzzer: ["_buzzer", "_notification_sound"],
   ionizer: ["_anion", "_ionizer"],
-  temperature: ["_temperature"],
-  humidity: ["_humidity"],
+  temperature: ["_temperature", "_temperatuur"],
+  humidity: ["_humidity", "_luchtvochtigheid"],
 };
 
 const findBySuffix = (
@@ -67,13 +67,14 @@ export const resolveRelatedEntities = async (
 
     const related: RelatedEntities = {};
     const numeric = ["number", "input_number"];
+    const angle = [...numeric, "select"];
     const boolean = ["switch", "input_boolean"];
     const select = ["select"];
 
-    related.horizontalAngle = findBySuffix(entries, numeric, suffixes.horizontalAngle);
+    related.horizontalAngle = findBySuffix(entries, angle, suffixes.horizontalAngle);
     related.sleepMode = findBySuffix(entries, [...boolean, "select"], suffixes.sleepMode);
     related.verticalSwing = findBySuffix(entries, [...boolean, "select"], suffixes.verticalSwing);
-    related.verticalAngle = findBySuffix(entries, numeric, suffixes.verticalAngle);
+    related.verticalAngle = findBySuffix(entries, angle, suffixes.verticalAngle);
     related.favoriteLevel = findBySuffix(entries, numeric, suffixes.favoriteLevel);
     related.timer = findBySuffix(entries, numeric, suffixes.timer);
     related.childLock = findBySuffix(entries, [...boolean, ...select], suffixes.childLock);

--- a/src/state/related-entities.ts
+++ b/src/state/related-entities.ts
@@ -5,6 +5,8 @@ interface RegistryEntity {
   device_id?: string;
   name?: string;
   original_name?: string;
+  device_class?: string;
+  original_device_class?: string;
 }
 
 const suffixes: Record<keyof RelatedEntities, string[]> = {
@@ -18,8 +20,8 @@ const suffixes: Record<keyof RelatedEntities, string[]> = {
   led: ["_led", "_led_brightness", "_light"],
   buzzer: ["_buzzer", "_notification_sound"],
   ionizer: ["_anion", "_ionizer"],
-  temperature: ["_temperature", "_temperatuur"],
-  humidity: ["_humidity", "_luchtvochtigheid"],
+  temperature: ["_temperature"],
+  humidity: ["_humidity"],
 };
 
 const findBySuffix = (
@@ -41,6 +43,29 @@ const findBySuffix = (
     const searchable = `${entry.entity_id} ${entry.name ?? ""} ${entry.original_name ?? ""}`.toLowerCase();
     return hintGroups.some((hints) => hints.every((hint) => searchable.includes(hint.toLowerCase())));
   })?.entity_id;
+};
+
+/**
+ * A translated Home Assistant install names sensors in the user language, so a
+ * suffix table would need one entry per locale. The device class is the same
+ * in every language and only falls back to the suffix search when missing.
+ */
+const findSensorByDeviceClass = (
+  hass: HassLike,
+  entries: RegistryEntity[],
+  deviceClass: string,
+  fallbackSuffixes: string[],
+): string | undefined => {
+  const match = entries.find((entry) => {
+    if (!entry.entity_id.startsWith("sensor.")) {
+      return false;
+    }
+
+    const registered = entry.device_class ?? entry.original_device_class;
+    return registered === deviceClass || hass.states[entry.entity_id]?.attributes["device_class"] === deviceClass;
+  });
+
+  return match?.entity_id ?? findBySuffix(entries, ["sensor"], fallbackSuffixes);
 };
 
 /**
@@ -71,11 +96,15 @@ export const resolveRelatedEntities = async (
     const boolean = ["switch", "input_boolean"];
     const select = ["select"];
 
+    // The vertical angle resolves first and then drops out of the remaining
+    // searches: `_vertical_oscillation_angle` also ends with the horizontal
+    // `_oscillation_angle`, and both angle names contain the vertical swing
+    // hints once a `select` angle entity is allowed.
     related.verticalAngle = findBySuffix(entries, angle, suffixes.verticalAngle);
     const withoutVerticalAngle = entries.filter((entry) => entry.entity_id !== related.verticalAngle);
     related.horizontalAngle = findBySuffix(withoutVerticalAngle, angle, suffixes.horizontalAngle);
     const withoutAngles = withoutVerticalAngle.filter((entry) => entry.entity_id !== related.horizontalAngle);
-    related.sleepMode = findBySuffix(entries, [...boolean, "select"], suffixes.sleepMode);
+    related.sleepMode = findBySuffix(withoutAngles, [...boolean, "select"], suffixes.sleepMode);
     related.verticalSwing = findBySuffix(withoutAngles, [...boolean, "select"], suffixes.verticalSwing);
     related.favoriteLevel = findBySuffix(entries, numeric, suffixes.favoriteLevel);
     related.timer = findBySuffix(entries, numeric, suffixes.timer);
@@ -83,8 +112,8 @@ export const resolveRelatedEntities = async (
     related.led = findBySuffix(entries, [...boolean, ...select, ...numeric], suffixes.led);
     related.buzzer = findBySuffix(entries, [...boolean, ...select], suffixes.buzzer);
     related.ionizer = findBySuffix(entries, [...boolean, ...select], suffixes.ionizer);
-    related.temperature = findBySuffix(entries, ["sensor"], suffixes.temperature);
-    related.humidity = findBySuffix(entries, ["sensor"], suffixes.humidity);
+    related.temperature = findSensorByDeviceClass(hass, entries, "temperature", suffixes.temperature);
+    related.humidity = findSensorByDeviceClass(hass, entries, "humidity", suffixes.humidity);
 
     return related;
   } catch {

--- a/src/state/related-entities.ts
+++ b/src/state/related-entities.ts
@@ -71,10 +71,12 @@ export const resolveRelatedEntities = async (
     const boolean = ["switch", "input_boolean"];
     const select = ["select"];
 
-    related.horizontalAngle = findBySuffix(entries, angle, suffixes.horizontalAngle);
-    related.sleepMode = findBySuffix(entries, [...boolean, "select"], suffixes.sleepMode);
-    related.verticalSwing = findBySuffix(entries, [...boolean, "select"], suffixes.verticalSwing);
     related.verticalAngle = findBySuffix(entries, angle, suffixes.verticalAngle);
+    const withoutVerticalAngle = entries.filter((entry) => entry.entity_id !== related.verticalAngle);
+    related.horizontalAngle = findBySuffix(withoutVerticalAngle, angle, suffixes.horizontalAngle);
+    const withoutAngles = withoutVerticalAngle.filter((entry) => entry.entity_id !== related.horizontalAngle);
+    related.sleepMode = findBySuffix(entries, [...boolean, "select"], suffixes.sleepMode);
+    related.verticalSwing = findBySuffix(withoutAngles, [...boolean, "select"], suffixes.verticalSwing);
     related.favoriteLevel = findBySuffix(entries, numeric, suffixes.favoriteLevel);
     related.timer = findBySuffix(entries, numeric, suffixes.timer);
     related.childLock = findBySuffix(entries, [...boolean, ...select], suffixes.childLock);

--- a/src/types.ts
+++ b/src/types.ts
@@ -225,9 +225,9 @@ export interface FanRelatedEntitiesConfig {
 }
 
 export const RELATED_ENTITY_DOMAINS = {
-  horizontal_angle_entity: ["number", "input_number"],
+  horizontal_angle_entity: ["number", "input_number", "select"],
   vertical_swing_entity: ["switch", "input_boolean", "select"],
-  vertical_angle_entity: ["number", "input_number"],
+  vertical_angle_entity: ["number", "input_number", "select"],
   favorite_level_entity: ["number", "input_number"],
   sleep_mode_entity: ["switch", "input_boolean", "select"],
   timer_entity: ["number", "input_number"],

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,11 +37,14 @@ export interface ServiceAvailability {
 
 export type TimerUnit = "min" | "s";
 
-export interface TimerSpec {
-  unit: TimerUnit;
+export interface NumberSpec {
   min: number;
   max: number;
   step: number;
+}
+
+export interface TimerSpec extends NumberSpec {
+  unit: TimerUnit;
 }
 
 export interface FanModelProfile {
@@ -66,9 +69,11 @@ export interface FanCapabilities {
   horizontalSwing: boolean;
   horizontalAngle: boolean;
   horizontalAngles: number[];
+  horizontalAngleSpec?: NumberSpec;
   verticalSwing: boolean;
   verticalAngle: boolean;
   verticalAngles: number[];
+  verticalAngleSpec?: NumberSpec;
   directionNudge: boolean;
   naturalMode: boolean;
   timer: boolean;

--- a/tests/component/card.test.ts
+++ b/tests/component/card.test.ts
@@ -200,6 +200,24 @@ describe("XiaomiFanCard", () => {
     expect(upButton).toBeTruthy();
   });
 
+  it("uses visibility flags to hide swing chips and angle controls", async () => {
+    const { card } = await renderCard({
+      ...baseConfig,
+      controls: {
+        ...baseConfig.controls,
+        show_horizontal_swing: false,
+        show_vertical_swing: false,
+        show_horizontal_angle: false,
+        show_vertical_angle: false,
+        show_nudge: false,
+        show_timer: false,
+      },
+    });
+
+    expect(card.shadowRoot?.querySelector(".chip-row")).toBeNull();
+    expect(card.shadowRoot?.querySelector(".angle-controls")).toBeNull();
+  });
+
   it("allows nudge controls with angles when explicitly enabled", async () => {
     const { card, callService } = await renderCard({
       ...baseConfig,

--- a/tests/component/card.test.ts
+++ b/tests/component/card.test.ts
@@ -218,6 +218,37 @@ describe("XiaomiFanCard", () => {
     expect(card.shadowRoot?.querySelector(".angle-controls")).toBeNull();
   });
 
+  it("bounds the numeric angle input by the related entity range", async () => {
+    const { hass } = createHass();
+    hass.states["fan.p76"] = {
+      state: "on",
+      attributes: { friendly_name: "Test fan", percentage: 50 },
+    };
+    hass.states["number.fan_horizontal"] = {
+      state: "60",
+      attributes: { min: 0, max: 120, step: 1 },
+    };
+    const card = new XiaomiFanCard();
+    card.hass = hass as unknown as HomeAssistant;
+    card.setConfig({
+      ...baseConfig,
+      controls: {
+        ...baseConfig.controls,
+        show_vertical_angle: false,
+        show_nudge: false,
+        show_timer: false,
+      },
+    });
+    document.body.append(card);
+    await settle(card);
+    const input = card.shadowRoot?.querySelector(".angle-controls input") as HTMLInputElement | null;
+
+    expect(card.shadowRoot?.querySelector(".angle-controls select")).toBeNull();
+    expect(input?.getAttribute("min")).toBe("0");
+    expect(input?.getAttribute("max")).toBe("120");
+    expect(input?.getAttribute("step")).toBe("1");
+  });
+
   it("allows nudge controls with angles when explicitly enabled", async () => {
     const { card, callService } = await renderCard({
       ...baseConfig,

--- a/tests/fixtures/air-purifier-4-pro.ts
+++ b/tests/fixtures/air-purifier-4-pro.ts
@@ -1,0 +1,154 @@
+import type { HassLike } from "../../src/types";
+
+const registry = [
+  { entity_id: "fan.air_purifier_4_pro", device_id: "device-air-purifier-4-pro" },
+  { entity_id: "number.air_purifier_4_pro_fan_level", device_id: "device-air-purifier-4-pro" },
+  { entity_id: "number.air_purifier_4_pro_favorite_level", device_id: "device-air-purifier-4-pro" },
+  { entity_id: "select.air_purifier_4_pro_led_brightness", device_id: "device-air-purifier-4-pro" },
+  { entity_id: "sensor.air_purifier_4_pro_filter_life_remaining", device_id: "device-air-purifier-4-pro" },
+  { entity_id: "sensor.air_purifier_4_pro_filter_lifetime_remaining", device_id: "device-air-purifier-4-pro" },
+  { entity_id: "sensor.air_purifier_4_pro_filter_use", device_id: "device-air-purifier-4-pro" },
+  { entity_id: "sensor.air_purifier_4_pro_luchtvochtigheid", device_id: "device-air-purifier-4-pro" },
+  { entity_id: "sensor.air_purifier_4_pro_motor_speed", device_id: "device-air-purifier-4-pro" },
+  { entity_id: "sensor.air_purifier_4_pro_pm10", device_id: "device-air-purifier-4-pro" },
+  { entity_id: "sensor.air_purifier_4_pro_pm2_5", device_id: "device-air-purifier-4-pro" },
+  { entity_id: "sensor.air_purifier_4_pro_temperatuur", device_id: "device-air-purifier-4-pro" },
+  { entity_id: "switch.air_purifier_4_pro_buzzer", device_id: "device-air-purifier-4-pro" },
+  { entity_id: "switch.air_purifier_4_pro_child_lock", device_id: "device-air-purifier-4-pro" },
+  { entity_id: "switch.air_purifier_4_pro_ionizer", device_id: "device-air-purifier-4-pro" },
+  { entity_id: "device_tracker.air_purifier_pro", device_id: "device-air-purifier-4-pro" },
+];
+
+const services = {
+  fan: {
+    toggle: {},
+    turn_on: {},
+    turn_off: {},
+    set_percentage: {},
+    set_preset_mode: {},
+    oscillate: {},
+  },
+  number: {
+    set_value: {},
+  },
+  select: {
+    select_option: {},
+  },
+  switch: {
+    turn_on: {},
+    turn_off: {},
+  },
+};
+
+export const airPurifier4ProHass = (): HassLike => ({
+  states: {
+    "fan.air_purifier_4_pro": {
+      state: "on",
+      attributes: {
+        friendly_name: "Xiaomi Smart Air Purifier 4 Pro",
+        percentage: 50,
+        preset_mode: "Auto",
+        preset_modes: ["Auto", "Silent", "Favorite", "Fan"],
+        supported_features: 8,
+      },
+    },
+    "number.air_purifier_4_pro_fan_level": {
+      state: "50",
+      attributes: {
+        min: 0,
+        max: 100,
+        step: 1,
+      },
+    },
+    "number.air_purifier_4_pro_favorite_level": {
+      state: "35",
+      attributes: {
+        min: 0,
+        max: 100,
+        step: 1,
+      },
+    },
+    "select.air_purifier_4_pro_led_brightness": {
+      state: "0",
+      attributes: {
+        options: ["0", "1", "2"],
+      },
+    },
+    "sensor.air_purifier_4_pro_filter_life_remaining": {
+      state: "87",
+      attributes: {
+        unit_of_measurement: "%",
+      },
+    },
+    "sensor.air_purifier_4_pro_filter_lifetime_remaining": {
+      state: "365",
+      attributes: {
+        unit_of_measurement: "d",
+      },
+    },
+    "sensor.air_purifier_4_pro_filter_use": {
+      state: "12",
+      attributes: {
+        unit_of_measurement: "d",
+      },
+    },
+    "sensor.air_purifier_4_pro_luchtvochtigheid": {
+      state: "46",
+      attributes: {
+        unit_of_measurement: "%",
+      },
+    },
+    "sensor.air_purifier_4_pro_motor_speed": {
+      state: "850",
+      attributes: {
+        unit_of_measurement: "rpm",
+      },
+    },
+    "sensor.air_purifier_4_pro_pm10": {
+      state: "4",
+      attributes: {
+        unit_of_measurement: "µg/m³",
+      },
+    },
+    "sensor.air_purifier_4_pro_pm2_5": {
+      state: "3",
+      attributes: {
+        unit_of_measurement: "µg/m³",
+      },
+    },
+    "sensor.air_purifier_4_pro_temperatuur": {
+      state: "23.5",
+      attributes: {
+        unit_of_measurement: "°C",
+      },
+    },
+    "switch.air_purifier_4_pro_buzzer": {
+      state: "off",
+      attributes: {},
+    },
+    "switch.air_purifier_4_pro_child_lock": {
+      state: "off",
+      attributes: {},
+    },
+    "switch.air_purifier_4_pro_ionizer": {
+      state: "on",
+      attributes: {},
+    },
+    "device_tracker.air_purifier_pro": {
+      state: "home",
+      attributes: {},
+    },
+  },
+  callService: () => undefined,
+  callWS: async <T>(message: Record<string, unknown>) => {
+    if (message.type === "config/entity_registry/list") {
+      return registry as T;
+    }
+
+    if (message.type === "get_services") {
+      return services as T;
+    }
+
+    return {} as T;
+  },
+});

--- a/tests/fixtures/air-purifier-4-pro.ts
+++ b/tests/fixtures/air-purifier-4-pro.ts
@@ -8,11 +8,23 @@ const registry = [
   { entity_id: "sensor.air_purifier_4_pro_filter_life_remaining", device_id: "device-air-purifier-4-pro" },
   { entity_id: "sensor.air_purifier_4_pro_filter_lifetime_remaining", device_id: "device-air-purifier-4-pro" },
   { entity_id: "sensor.air_purifier_4_pro_filter_use", device_id: "device-air-purifier-4-pro" },
-  { entity_id: "sensor.air_purifier_4_pro_luchtvochtigheid", device_id: "device-air-purifier-4-pro" },
+  {
+    entity_id: "sensor.air_purifier_4_pro_luchtvochtigheid",
+    device_id: "device-air-purifier-4-pro",
+    original_device_class: "humidity",
+  },
   { entity_id: "sensor.air_purifier_4_pro_motor_speed", device_id: "device-air-purifier-4-pro" },
   { entity_id: "sensor.air_purifier_4_pro_pm10", device_id: "device-air-purifier-4-pro" },
-  { entity_id: "sensor.air_purifier_4_pro_pm2_5", device_id: "device-air-purifier-4-pro" },
-  { entity_id: "sensor.air_purifier_4_pro_temperatuur", device_id: "device-air-purifier-4-pro" },
+  {
+    entity_id: "sensor.air_purifier_4_pro_pm2_5",
+    device_id: "device-air-purifier-4-pro",
+    original_device_class: "pm25",
+  },
+  {
+    entity_id: "sensor.air_purifier_4_pro_temperatuur",
+    device_id: "device-air-purifier-4-pro",
+    original_device_class: "temperature",
+  },
   { entity_id: "switch.air_purifier_4_pro_buzzer", device_id: "device-air-purifier-4-pro" },
   { entity_id: "switch.air_purifier_4_pro_child_lock", device_id: "device-air-purifier-4-pro" },
   { entity_id: "switch.air_purifier_4_pro_ionizer", device_id: "device-air-purifier-4-pro" },
@@ -95,6 +107,7 @@ export const airPurifier4ProHass = (): HassLike => ({
     "sensor.air_purifier_4_pro_luchtvochtigheid": {
       state: "46",
       attributes: {
+        device_class: "humidity",
         unit_of_measurement: "%",
       },
     },
@@ -119,6 +132,7 @@ export const airPurifier4ProHass = (): HassLike => ({
     "sensor.air_purifier_4_pro_temperatuur": {
       state: "23.5",
       attributes: {
+        device_class: "temperature",
         unit_of_measurement: "°C",
       },
     },

--- a/tests/fixtures/xiaomi-miot-p76.ts
+++ b/tests/fixtures/xiaomi-miot-p76.ts
@@ -1,0 +1,68 @@
+import type { HassLike } from "../../src/types";
+
+const registry = [
+  { entity_id: "fan.xiaomi_p76", device_id: "device-miot-p76" },
+  { entity_id: "select.xiaomi_p76_horizontal_swing_angle", device_id: "device-miot-p76" },
+  { entity_id: "select.xiaomi_p76_vertical_swing_angle", device_id: "device-miot-p76" },
+  { entity_id: "select.xiaomi_p76_vertical_swing", device_id: "device-miot-p76" },
+];
+
+const services = {
+  fan: {
+    toggle: {},
+    turn_on: {},
+    turn_off: {},
+    set_percentage: {},
+    set_preset_mode: {},
+    oscillate: {},
+  },
+  select: {
+    select_option: {},
+  },
+};
+
+export const xiaomiMiotP76Hass = (): HassLike => ({
+  states: {
+    "fan.xiaomi_p76": {
+      state: "on",
+      attributes: {
+        friendly_name: "Xiaomi Smart Standing Air Circulation Fan",
+        model: "xiaomi.fan.p76",
+        percentage: 50,
+        preset_mode: "Level 2",
+        preset_modes: ["off", "Level 1", "Level 2", "Level 3", "Level 4", "Natural 1", "Natural 2"],
+        oscillating: false,
+      },
+    },
+    "select.xiaomi_p76_horizontal_swing_angle": {
+      state: "60 degrees",
+      attributes: {
+        options: ["30°", "60 degrees", "90°", "120 degrees"],
+      },
+    },
+    "select.xiaomi_p76_vertical_swing_angle": {
+      state: "30°",
+      attributes: {
+        options: ["30°", "60 degrees", "90°", "100 degrees"],
+      },
+    },
+    "select.xiaomi_p76_vertical_swing": {
+      state: "on",
+      attributes: {
+        options: ["off", "on"],
+      },
+    },
+  },
+  callService: () => undefined,
+  callWS: async <T>(message: Record<string, unknown>) => {
+    if (message.type === "config/entity_registry/list") {
+      return registry as T;
+    }
+
+    if (message.type === "get_services") {
+      return services as T;
+    }
+
+    return {} as T;
+  },
+});

--- a/tests/fixtures/xiaomi-miot-p76.ts
+++ b/tests/fixtures/xiaomi-miot-p76.ts
@@ -35,15 +35,15 @@ export const xiaomiMiotP76Hass = (): HassLike => ({
       },
     },
     "select.xiaomi_p76_horizontal_swing_angle": {
-      state: "60 degrees",
+      state: "60",
       attributes: {
-        options: ["30°", "60 degrees", "90°", "120 degrees"],
+        options: ["30", "60", "90", "120"],
       },
     },
     "select.xiaomi_p76_vertical_swing_angle": {
-      state: "30°",
+      state: "30",
       attributes: {
-        options: ["30°", "60 degrees", "90°", "100 degrees"],
+        options: ["30", "60", "90", "100"],
       },
     },
     "select.xiaomi_p76_vertical_swing": {

--- a/tests/unit/capabilities.test.ts
+++ b/tests/unit/capabilities.test.ts
@@ -40,4 +40,26 @@ describe("detectCapabilities", () => {
     expect(capabilities.timer).toBe(false);
     expect(capabilities.childLock).toBe(false);
   });
+
+  it("does not treat preset-only feature bit as swing support", () => {
+    const capabilities = detectCapabilities({
+      state: "on",
+      attributes: { supported_features: 8 },
+    });
+
+    expect(capabilities.horizontalSwing).toBe(false);
+    expect(capabilities.verticalSwing).toBe(false);
+    expect(capabilities.horizontalAngle).toBe(false);
+    expect(capabilities.verticalAngle).toBe(false);
+  });
+
+  it("honors the official oscillation and direction feature bits", () => {
+    const capabilities = detectCapabilities({
+      state: "on",
+      attributes: { supported_features: 6 },
+    });
+
+    expect(capabilities.horizontalSwing).toBe(true);
+    expect(capabilities.direction).toBe(true);
+  });
 });

--- a/tests/unit/integration-regressions.test.ts
+++ b/tests/unit/integration-regressions.test.ts
@@ -54,8 +54,8 @@ describe("integration regression fixtures", () => {
 
     expect(calls).toEqual([
       ["fan", "oscillate", { entity_id: "fan.xiaomi_p76", oscillating: true }],
-      ["select", "select_option", { entity_id: "select.xiaomi_p76_horizontal_swing_angle", option: "90°" }],
-      ["select", "select_option", { entity_id: "select.xiaomi_p76_vertical_swing_angle", option: "60 degrees" }],
+      ["select", "select_option", { entity_id: "select.xiaomi_p76_horizontal_swing_angle", option: "90" }],
+      ["select", "select_option", { entity_id: "select.xiaomi_p76_vertical_swing_angle", option: "60" }],
       ["select", "select_option", { entity_id: "select.xiaomi_p76_vertical_swing", option: "off" }],
       ["fan", "set_percentage", { entity_id: "fan.xiaomi_p76", percentage: 75 }],
       ["fan", "set_preset_mode", { entity_id: "fan.xiaomi_p76", preset_mode: "Natural 2" }],

--- a/tests/unit/integration-regressions.test.ts
+++ b/tests/unit/integration-regressions.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import { createFanAdapter } from "../../src/adapters";
+import { StandardFanAdapter } from "../../src/adapters/standard-fan";
+import { loadServiceAvailability } from "../../src/services/service-dispatcher";
+import { resolveRelatedEntities } from "../../src/state/related-entities";
+import type { HassLike } from "../../src/types";
+import { airPurifier4ProHass } from "../fixtures/air-purifier-4-pro";
+import { xiaomiMiotP76Hass } from "../fixtures/xiaomi-miot-p76";
+
+describe("integration regression fixtures", () => {
+  it("discovers MIoT P76 controls and dispatches standard and select services", async () => {
+    const hass = xiaomiMiotP76Hass();
+    const services = await loadServiceAvailability(hass);
+    const related = await resolveRelatedEntities(hass, "fan.xiaomi_p76");
+
+    expect(related).toEqual({
+      sleepMode: undefined,
+      verticalSwing: "select.xiaomi_p76_vertical_swing",
+      horizontalAngle: "select.xiaomi_p76_horizontal_swing_angle",
+      verticalAngle: "select.xiaomi_p76_vertical_swing_angle",
+      favoriteLevel: undefined,
+      timer: undefined,
+      childLock: undefined,
+      led: undefined,
+      buzzer: undefined,
+      ionizer: undefined,
+      temperature: undefined,
+      humidity: undefined,
+    });
+    expect([...services.names].some((name) => name.startsWith("xiaomi_miio_fan."))).toBe(false);
+
+    const withoutRelated = createFanAdapter(hass, "fan.xiaomi_p76", services, "xiaomi_miot");
+    expect(withoutRelated.capabilities.verticalSwing).toBe(false);
+    expect(withoutRelated.capabilities.horizontalAngle).toBe(false);
+    expect(withoutRelated.capabilities.verticalAngle).toBe(false);
+
+    const adapter = createFanAdapter(hass, "fan.xiaomi_p76", services, "xiaomi_miot", related);
+    const calls: unknown[][] = [];
+    hass.callService = (...args) => {
+      calls.push(args);
+    };
+
+    expect(adapter.capabilities.verticalSwing).toBe(true);
+    expect(adapter.capabilities.horizontalAngle).toBe(true);
+    expect(adapter.capabilities.verticalAngle).toBe(true);
+    expect(adapter.capabilities.horizontalAngles).toEqual([30, 60, 90, 120]);
+    expect(adapter.capabilities.verticalAngles).toEqual([30, 60, 90, 100]);
+
+    await adapter.setHorizontalAngle(90);
+    await adapter.setVerticalAngle(60);
+    await adapter.setVerticalSwing(false);
+    await adapter.setPercentage(75);
+    await adapter.setPresetMode("Natural 2");
+
+    expect(calls).toEqual([
+      ["fan", "oscillate", { entity_id: "fan.xiaomi_p76", oscillating: true }],
+      ["select", "select_option", { entity_id: "select.xiaomi_p76_horizontal_swing_angle", option: "90°" }],
+      ["select", "select_option", { entity_id: "select.xiaomi_p76_vertical_swing_angle", option: "60 degrees" }],
+      ["select", "select_option", { entity_id: "select.xiaomi_p76_vertical_swing", option: "off" }],
+      ["fan", "set_percentage", { entity_id: "fan.xiaomi_p76", percentage: 75 }],
+      ["fan", "set_preset_mode", { entity_id: "fan.xiaomi_p76", preset_mode: "Natural 2" }],
+    ]);
+    expect(calls.some(([domain]) => domain === "xiaomi_miio_fan")).toBe(false);
+  });
+
+  it("discovers purifier extras without inventing swing or angle controls", async () => {
+    const hass = airPurifier4ProHass();
+    const services = await loadServiceAvailability(hass);
+    const related = await resolveRelatedEntities(hass, "fan.air_purifier_4_pro");
+
+    expect(related).toEqual({
+      sleepMode: undefined,
+      verticalSwing: undefined,
+      horizontalAngle: undefined,
+      verticalAngle: undefined,
+      favoriteLevel: "number.air_purifier_4_pro_favorite_level",
+      timer: undefined,
+      childLock: "switch.air_purifier_4_pro_child_lock",
+      led: "select.air_purifier_4_pro_led_brightness",
+      buzzer: "switch.air_purifier_4_pro_buzzer",
+      ionizer: "switch.air_purifier_4_pro_ionizer",
+      temperature: "sensor.air_purifier_4_pro_temperatuur",
+      humidity: "sensor.air_purifier_4_pro_luchtvochtigheid",
+    });
+
+    const adapter = createFanAdapter(hass, "fan.air_purifier_4_pro", services, "standard", related);
+    const calls: unknown[][] = [];
+    hass.callService = (...args) => {
+      calls.push(args);
+    };
+
+    expect(adapter).toBeInstanceOf(StandardFanAdapter);
+    expect(adapter.capabilities.horizontalSwing).toBe(false);
+    expect(adapter.capabilities.horizontalAngle).toBe(false);
+    expect(adapter.capabilities.verticalSwing).toBe(false);
+    expect(adapter.capabilities.verticalAngle).toBe(false);
+    expect(adapter.capabilities.favoriteLevel).toBe(true);
+    expect(adapter.capabilities.led).toBe(true);
+    expect(adapter.capabilities.buzzer).toBe(true);
+    expect(adapter.capabilities.childLock).toBe(true);
+    expect(adapter.capabilities.ionizer).toBe(true);
+    expect(adapter.state.led).toBe(true);
+    expect(adapter.state.temperature).toBe("23.5");
+    expect(adapter.state.humidity).toBe("46");
+
+    await adapter.setLed(false);
+    await adapter.setLed(true);
+    expect(calls).toEqual([
+      ["select", "select_option", { entity_id: "select.air_purifier_4_pro_led_brightness", option: "2" }],
+      ["select", "select_option", { entity_id: "select.air_purifier_4_pro_led_brightness", option: "0" }],
+    ]);
+  });
+
+  it("does not advertise angle controls for non-numeric select options", async () => {
+    const hass: HassLike = {
+      states: {
+        "fan.invalid_angles": {
+          state: "on",
+          attributes: {
+            supported_features: 0,
+          },
+        },
+        "select.invalid_horizontal_angle": {
+          state: "Auto",
+          attributes: {
+            options: ["Auto", "Manual"],
+          },
+        },
+        "select.invalid_vertical_angle": {
+          state: "Fixed",
+          attributes: {
+            options: ["Fixed", "Oscillating"],
+          },
+        },
+      },
+      callService: () => undefined,
+    };
+    const services = await loadServiceAvailability(hass);
+    const adapter = new StandardFanAdapter(hass, "fan.invalid_angles", services, {
+      horizontalAngle: "select.invalid_horizontal_angle",
+      verticalAngle: "select.invalid_vertical_angle",
+    });
+
+    expect(adapter.capabilities.horizontalAngle).toBe(false);
+    expect(adapter.capabilities.verticalAngle).toBe(false);
+    expect(adapter.capabilities.horizontalAngles).toEqual([]);
+    expect(adapter.capabilities.verticalAngles).toEqual([]);
+  });
+});

--- a/tests/unit/normalize-state.test.ts
+++ b/tests/unit/normalize-state.test.ts
@@ -63,4 +63,29 @@ describe("normalizeFanState", () => {
     expect(state.timerMinutes).toBe(53);
     expect(state.led).toBe(false);
   });
+
+  it("prefers LED brightness over a stale LED flag", () => {
+    const state = normalizeFanState("fan.led", {
+      state: "on",
+      attributes: {
+        led: true,
+        led_brightness: 2,
+      },
+    });
+
+    expect(state.led).toBe(false);
+  });
+
+  it("reads angles written as decorated select labels", () => {
+    const state = normalizeFanState("fan.angles", {
+      state: "on",
+      attributes: {
+        horizontal_swing_angle: "90°",
+        vertical_swing_angle: "60 degrees",
+      },
+    });
+
+    expect(state.horizontalAngle).toBe(90);
+    expect(state.verticalAngle).toBe(60);
+  });
 });

--- a/tests/unit/related-entities.test.ts
+++ b/tests/unit/related-entities.test.ts
@@ -61,6 +61,24 @@ describe("resolveRelatedEntities", () => {
     });
   });
 
+  it("keeps vertical angle selects out of horizontal angle and swing roles", async () => {
+    const hass: HassLike = {
+      states: { "fan.example": { state: "on", attributes: {} } },
+      callService: () => undefined,
+      callWS: async <T>() =>
+        [
+          { entity_id: "fan.example", device_id: "device-1" },
+          { entity_id: "select.example_vertical_oscillation_angle", device_id: "device-1" },
+        ] as T,
+    };
+
+    await expect(resolveRelatedEntities(hass, "fan.example")).resolves.toMatchObject({
+      horizontalAngle: undefined,
+      verticalSwing: undefined,
+      verticalAngle: "select.example_vertical_oscillation_angle",
+    });
+  });
+
   it("reports an empty device when the fan has no registry siblings", async () => {
     const hass: HassLike = {
       states: { "fan.example": { state: "on", attributes: {} } },

--- a/tests/unit/related-entities.test.ts
+++ b/tests/unit/related-entities.test.ts
@@ -13,6 +13,8 @@ describe("resolveRelatedEntities", () => {
         [
           { entity_id: "fan.example", device_id: "device-1" },
           { entity_id: "number.example_timer", device_id: "device-1" },
+          { entity_id: "select.example_horizontal_angle", device_id: "device-1" },
+          { entity_id: "select.example_vertical_angle", device_id: "device-1" },
           { entity_id: "select.example_led", device_id: "device-1" },
           { entity_id: "input_boolean.example_child_lock", device_id: "device-1" },
           { entity_id: "sensor.example_temperature", device_id: "device-1" },
@@ -20,10 +22,12 @@ describe("resolveRelatedEntities", () => {
     };
 
     await expect(resolveRelatedEntities(hass, "fan.example")).resolves.toEqual({
+      horizontalAngle: "select.example_horizontal_angle",
       timer: "number.example_timer",
       led: "select.example_led",
       childLock: "input_boolean.example_child_lock",
       temperature: "sensor.example_temperature",
+      verticalAngle: "select.example_vertical_angle",
     });
   });
 
@@ -37,6 +41,24 @@ describe("resolveRelatedEntities", () => {
     };
 
     await expect(resolveRelatedEntities(hass, "fan.example")).resolves.toBeUndefined();
+  });
+
+  it("discovers localized temperature and humidity suffixes", async () => {
+    const hass: HassLike = {
+      states: { "fan.example": { state: "on", attributes: {} } },
+      callService: () => undefined,
+      callWS: async <T>() =>
+        [
+          { entity_id: "fan.example", device_id: "device-1" },
+          { entity_id: "sensor.example_temperatuur", device_id: "device-1" },
+          { entity_id: "sensor.example_luchtvochtigheid", device_id: "device-1" },
+        ] as T,
+    };
+
+    await expect(resolveRelatedEntities(hass, "fan.example")).resolves.toEqual({
+      humidity: "sensor.example_luchtvochtigheid",
+      temperature: "sensor.example_temperatuur",
+    });
   });
 
   it("reports an empty device when the fan has no registry siblings", async () => {

--- a/tests/unit/related-entities.test.ts
+++ b/tests/unit/related-entities.test.ts
@@ -43,14 +43,17 @@ describe("resolveRelatedEntities", () => {
     await expect(resolveRelatedEntities(hass, "fan.example")).resolves.toBeUndefined();
   });
 
-  it("discovers localized temperature and humidity suffixes", async () => {
+  it("discovers localized sensors through their device class", async () => {
     const hass: HassLike = {
-      states: { "fan.example": { state: "on", attributes: {} } },
+      states: {
+        "fan.example": { state: "on", attributes: {} },
+        "sensor.example_luchtvochtigheid": { state: "46", attributes: { device_class: "humidity" } },
+      },
       callService: () => undefined,
       callWS: async <T>() =>
         [
           { entity_id: "fan.example", device_id: "device-1" },
-          { entity_id: "sensor.example_temperatuur", device_id: "device-1" },
+          { entity_id: "sensor.example_temperatuur", device_id: "device-1", original_device_class: "temperature" },
           { entity_id: "sensor.example_luchtvochtigheid", device_id: "device-1" },
         ] as T,
     };
@@ -58,6 +61,24 @@ describe("resolveRelatedEntities", () => {
     await expect(resolveRelatedEntities(hass, "fan.example")).resolves.toEqual({
       humidity: "sensor.example_luchtvochtigheid",
       temperature: "sensor.example_temperatuur",
+    });
+  });
+
+  it("falls back to the English suffix when no sensor declares a device class", async () => {
+    const hass: HassLike = {
+      states: { "fan.example": { state: "on", attributes: {} } },
+      callService: () => undefined,
+      callWS: async <T>() =>
+        [
+          { entity_id: "fan.example", device_id: "device-1" },
+          { entity_id: "sensor.example_temperature", device_id: "device-1" },
+          { entity_id: "sensor.example_humidity", device_id: "device-1" },
+        ] as T,
+    };
+
+    await expect(resolveRelatedEntities(hass, "fan.example")).resolves.toEqual({
+      humidity: "sensor.example_humidity",
+      temperature: "sensor.example_temperature",
     });
   });
 

--- a/tests/unit/standard-adapter.test.ts
+++ b/tests/unit/standard-adapter.test.ts
@@ -100,6 +100,22 @@ describe("StandardFanAdapter", () => {
     ]);
   });
 
+  it("dispatches semantic LED select options", async () => {
+    const { hass, calls } = createHass([], []);
+    hass.states["select.example_led"] = {
+      state: "off",
+      attributes: { options: ["off", "on"] },
+    };
+    const adapter = new StandardFanAdapter(hass, "fan.example", services, {
+      led: "select.example_led",
+    });
+
+    expect(adapter.state.led).toBe(false);
+    await adapter.setLed(true);
+
+    expect(calls).toEqual([["select", "select_option", { entity_id: "select.example_led", option: "on" }]]);
+  });
+
   it("falls back to the existing custom angle service when select options do not match", async () => {
     const { hass, calls } = createHass(["0", "15 degrees"], ["30", "60 degrees"]);
     const adapter = new StandardFanAdapter(hass, "fan.example", services, {

--- a/tests/unit/standard-adapter.test.ts
+++ b/tests/unit/standard-adapter.test.ts
@@ -60,6 +60,46 @@ describe("StandardFanAdapter", () => {
     ]);
   });
 
+  it("sorts numeric angle options for cycle controls", () => {
+    const { hass } = createHass(["90", "30°", "60"], ["90", "30", "60"]);
+    const adapter = new StandardFanAdapter(hass, "fan.example", services, {
+      horizontalAngle: "select.example_horizontal_angle",
+      verticalAngle: "select.example_vertical_angle",
+    });
+
+    expect(adapter.capabilities.horizontalAngles).toEqual([30, 60, 90]);
+    expect(adapter.capabilities.verticalAngles).toEqual([30, 60, 90]);
+  });
+
+  it("keeps generic numeric LED state and actions aligned", async () => {
+    const { hass, calls } = createHass([], []);
+    hass.states["number.example_led"] = {
+      state: "0",
+      attributes: { min: 0, max: 100, step: 1 },
+    };
+
+    const offAdapter = new StandardFanAdapter(hass, "fan.example", services, {
+      led: "number.example_led",
+    });
+    expect(offAdapter.state.led).toBe(false);
+    await offAdapter.setLed(true);
+
+    hass.states["number.example_led"] = {
+      state: "100",
+      attributes: { min: 0, max: 100, step: 1 },
+    };
+    const onAdapter = new StandardFanAdapter(hass, "fan.example", services, {
+      led: "number.example_led",
+    });
+    expect(onAdapter.state.led).toBe(true);
+    await onAdapter.setLed(false);
+
+    expect(calls).toEqual([
+      ["number", "set_value", { entity_id: "number.example_led", value: 100 }],
+      ["number", "set_value", { entity_id: "number.example_led", value: 0 }],
+    ]);
+  });
+
   it("falls back to the existing custom angle service when select options do not match", async () => {
     const { hass, calls } = createHass(["0", "15 degrees"], ["30", "60 degrees"]);
     const adapter = new StandardFanAdapter(hass, "fan.example", services, {

--- a/tests/unit/standard-adapter.test.ts
+++ b/tests/unit/standard-adapter.test.ts
@@ -127,4 +127,100 @@ describe("StandardFanAdapter", () => {
 
     expect(calls).toEqual([["xiaomi_miio_fan", "fan_set_oscillation_angle", { entity_id: "fan.example", angle: 30 }]]);
   });
+
+  it("keeps the primary angle attribute when a mode select is matched as an angle entity", () => {
+    const { hass } = createHass(["Auto", "Manual"], ["Auto", "Manual"]);
+    hass.states["fan.example"] = {
+      state: "on",
+      attributes: { horizontal_swing_angle: 60, vertical_swing_angle: 30 },
+    };
+    hass.states["select.example_horizontal_angle"] = {
+      state: "Auto",
+      attributes: { options: ["Auto", "Manual"] },
+    };
+    hass.states["select.example_vertical_angle"] = {
+      state: "Manual",
+      attributes: { options: ["Auto", "Manual"] },
+    };
+    const adapter = new StandardFanAdapter(hass, "fan.example", services, {
+      horizontalAngle: "select.example_horizontal_angle",
+      verticalAngle: "select.example_vertical_angle",
+    });
+
+    expect(adapter.state.horizontalAngle).toBe(60);
+    expect(adapter.state.verticalAngle).toBe(30);
+  });
+
+  it("turns an LED brightness select off instead of dimming it", async () => {
+    const { hass, calls } = createHass([], []);
+    hass.states["select.example_led_brightness"] = {
+      state: "Bright",
+      attributes: { options: ["Bright", "Dim", "Off"] },
+    };
+    const adapter = new StandardFanAdapter(hass, "fan.example", services, {
+      led: "select.example_led_brightness",
+    });
+
+    expect(adapter.state.led).toBe(true);
+    await adapter.setLed(false);
+    await adapter.setLed(true);
+
+    expect(calls).toEqual([
+      ["select", "select_option", { entity_id: "select.example_led_brightness", option: "Off" }],
+      ["select", "select_option", { entity_id: "select.example_led_brightness", option: "Bright" }],
+    ]);
+  });
+
+  it("reads a dimmed LED select as lit", () => {
+    const { hass } = createHass([], []);
+    hass.states["select.example_led_brightness"] = {
+      state: "Dim",
+      attributes: { options: ["Bright", "Dim", "Off"] },
+    };
+    const adapter = new StandardFanAdapter(hass, "fan.example", services, {
+      led: "select.example_led_brightness",
+    });
+
+    expect(adapter.state.led).toBe(true);
+  });
+
+  it("does not pick an unrelated option that merely contains a boolean token", async () => {
+    const { hass } = createHass([], []);
+    hass.states["select.example_sleep_mode"] = {
+      state: "None",
+      attributes: { options: ["None", "Constant"] },
+    };
+    const adapter = new StandardFanAdapter(hass, "fan.example", services, {
+      sleepMode: "select.example_sleep_mode",
+    });
+
+    await expect(adapter.setSleepMode(true)).rejects.toThrow("has no matching boolean option");
+  });
+
+  it("reports an angle spec instead of an unusable preset list for a fine-grained number", () => {
+    const { hass } = createHass([], []);
+    hass.states["number.example_horizontal_angle"] = {
+      state: "60",
+      attributes: { min: 0, max: 120, step: 1, unit_of_measurement: "°" },
+    };
+    const adapter = new StandardFanAdapter(hass, "fan.example", services, {
+      horizontalAngle: "number.example_horizontal_angle",
+    });
+
+    expect(adapter.capabilities.horizontalAngles).toEqual([]);
+    expect(adapter.capabilities.horizontalAngleSpec).toEqual({ min: 0, max: 120, step: 1 });
+  });
+
+  it("keeps angle steps free of timer unit conversion", () => {
+    const { hass } = createHass([], []);
+    hass.states["number.example_vertical_angle"] = {
+      state: "60",
+      attributes: { min: 0, max: 120, step: 30, unit_of_measurement: "s" },
+    };
+    const adapter = new StandardFanAdapter(hass, "fan.example", services, {
+      verticalAngle: "number.example_vertical_angle",
+    });
+
+    expect(adapter.capabilities.verticalAngles).toEqual([0, 30, 60, 90, 120]);
+  });
 });

--- a/tests/unit/standard-adapter.test.ts
+++ b/tests/unit/standard-adapter.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { StandardFanAdapter } from "../../src/adapters/standard-fan";
+import { readServiceAvailability } from "../../src/services/service-dispatcher";
+import type { HassLike } from "../../src/types";
+
+const services = readServiceAvailability({
+  fan: {
+    oscillate: {},
+  },
+  xiaomi_miio_fan: {
+    fan_set_oscillation_angle: {},
+    fan_set_vertical_oscillation_angle: {},
+  },
+});
+
+const createHass = (horizontalOptions: unknown[], verticalOptions: unknown[]) => {
+  const calls: unknown[][] = [];
+  const hass: HassLike = {
+    states: {
+      "fan.example": {
+        state: "on",
+        attributes: { friendly_name: "Example fan" },
+      },
+      "select.example_horizontal_angle": {
+        state: "30°",
+        attributes: { options: horizontalOptions },
+      },
+      "select.example_vertical_angle": {
+        state: "60 degrees",
+        attributes: { options: verticalOptions },
+      },
+    },
+    callService: (...args) => {
+      calls.push(args);
+    },
+  };
+
+  return { hass, calls };
+};
+
+describe("StandardFanAdapter", () => {
+  it("dispatches numeric angle options through select entities", async () => {
+    const { hass, calls } = createHass(["0", "30°", "60"], ["30", "60 degrees", "90"]);
+    const adapter = new StandardFanAdapter(hass, "fan.example", services, {
+      horizontalAngle: "select.example_horizontal_angle",
+      verticalAngle: "select.example_vertical_angle",
+    });
+
+    expect(adapter.state.horizontalAngle).toBe(30);
+    expect(adapter.state.verticalAngle).toBe(60);
+    expect(adapter.capabilities.horizontalAngles).toEqual([0, 30, 60]);
+    expect(adapter.capabilities.verticalAngles).toEqual([30, 60, 90]);
+
+    await adapter.setHorizontalAngle(30);
+    await adapter.setVerticalAngle(60);
+
+    expect(calls).toEqual([
+      ["select", "select_option", { entity_id: "select.example_horizontal_angle", option: "30°" }],
+      ["select", "select_option", { entity_id: "select.example_vertical_angle", option: "60 degrees" }],
+    ]);
+  });
+
+  it("falls back to the existing custom angle service when select options do not match", async () => {
+    const { hass, calls } = createHass(["0", "15 degrees"], ["30", "60 degrees"]);
+    const adapter = new StandardFanAdapter(hass, "fan.example", services, {
+      horizontalAngle: "select.example_horizontal_angle",
+      verticalAngle: "select.example_vertical_angle",
+    });
+
+    await adapter.setHorizontalAngle(30);
+
+    expect(calls).toEqual([["xiaomi_miio_fan", "fan_set_oscillation_angle", { entity_id: "fan.example", angle: 30 }]]);
+  });
+});


### PR DESCRIPTION
## Summary

- Fix HACS repository redirect parameters.
- Correct Home Assistant oscillation and direction feature bits.
- Add MIoT P76 related select discovery and service dispatch.
- Hide unsupported swing and angle controls for preset-only purifiers.
- Add deterministic P76 and Air Purifier 4 Pro fixtures and regression tests.
- Expand integration, configuration, and troubleshooting documentation.
- Rebuild tracked HACS bundle.

Closes #26

## Validation

- `npm run validate`
- 14 test files, 86 tests passed
- Formatting, lint, typecheck, coverage, and build passed
- Rollup emitted known `@formatjs/intl-utils` `this` rewrite warning only

Live Home Assistant device verification remains supplemental.
