### PR TITLE
fix(editor): allow multi-digit visual sizes

### DIFF
--- a/dist/xiaomi-fan-card.js
+++ b/dist/xiaomi-fan-card.js
@@ -1295,6 +1295,8 @@ const DEFAULT_VISUAL_SIZE = 300;
 const VISUAL_SIZE_MIN = 120;
 const VISUAL_SIZE_MAX = 480;
 const VISUAL_SIZE_STEP = 10;
+// Keep the first digits of a multi-digit mobile edit valid until the final value is entered.
+const VISUAL_SIZE_EDITOR_MIN = 1;
 const SURFACE_STYLE_TOKENS = [
     "background",
     "border",
@@ -1650,7 +1652,7 @@ const getConfigForm = () => {
                     name: "size",
                     selector: {
                         number: {
-                            min: VISUAL_SIZE_MIN,
+                            min: VISUAL_SIZE_EDITOR_MIN,
                             max: VISUAL_SIZE_MAX,
                             step: VISUAL_SIZE_STEP,
                             mode: "box",

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,6 +26,8 @@ export const DEFAULT_VISUAL_SIZE = 300;
 export const VISUAL_SIZE_MIN = 120;
 export const VISUAL_SIZE_MAX = 480;
 export const VISUAL_SIZE_STEP = 10;
+// Keep the first digits of a multi-digit mobile edit valid until the final value is entered.
+export const VISUAL_SIZE_EDITOR_MIN = 1;
 
 const SURFACE_STYLE_TOKENS = [
   "background",

--- a/src/editor-schema.ts
+++ b/src/editor-schema.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_BLOCK_ORDER, STYLE_TOKENS, VISUAL_SIZE_MAX, VISUAL_SIZE_MIN, VISUAL_SIZE_STEP } from "./config";
+import { DEFAULT_BLOCK_ORDER, STYLE_TOKENS, VISUAL_SIZE_EDITOR_MIN, VISUAL_SIZE_MAX, VISUAL_SIZE_STEP } from "./config";
 import { RELATED_ENTITY_DOMAINS } from "./types";
 import type { FanRelatedEntitiesConfig } from "./types";
 
@@ -79,7 +79,7 @@ export const getConfigForm = () => {
             name: "size",
             selector: {
               number: {
-                min: VISUAL_SIZE_MIN,
+                min: VISUAL_SIZE_EDITOR_MIN,
                 max: VISUAL_SIZE_MAX,
                 step: VISUAL_SIZE_STEP,
                 mode: "box",

--- a/tests/component/card.test.ts
+++ b/tests/component/card.test.ts
@@ -382,7 +382,7 @@ describe("XiaomiFanCard", () => {
     ]);
     expect(panelFields(schema, "visual").find((field) => field.name === "size")?.selector).toEqual({
       number: {
-        min: 120,
+        min: 1,
         max: 480,
         step: 10,
         mode: "box",


### PR DESCRIPTION
## Summary
- keep runtime visual-size clamping at 120-480 px
- allow mobile editor input values such as 150
- regenerate the tracked HACS bundle

## Root cause
Home Assistant validates the number selector after each keystroke. With min=120, the first digit of a multi-digit mobile value is immediately clamped to a boundary, preventing entry of values such as 150.

## Validation
- npm run validate
- 100 tests passed
- lint, typecheck, coverage, and build passed