### PR TITLE
fix: show position pad from Xiaomi Home turn buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,10 @@ what it can._
 
 Nudge arrows are hidden by default when angle controls exist, because both
 target the same fan position. Set `controls.show_nudge_with_angles: true` to
-show both, as in the position block above.
+show both, as in the position block above. The pad also appears for Xiaomi Home
+devices that expose `turn_left`, `turn_right`, `turn_upward`, and
+`turn_downward` buttons: the card discovers them on the same device and presses
+them instead of calling vendor services.
 
 Timer values are shown in minutes. The custom `xiaomi_miio_fan` integration
 uses seconds for `zhimi.fan.za5`; the card converts that model-specific

--- a/dist/xiaomi-fan-card.js
+++ b/dist/xiaomi-fan-card.js
@@ -561,6 +561,9 @@ const detectCapabilities = (entity, services = { loaded: false, names: new Set()
                 profile.known));
     const presetMode = hasFanFeature(entity, FAN_FEATURE_PRESET_MODE) || (!explicitFeatureMask && (hasPresetAttributes || profile.known));
     const xiaomiCustomModel = isXiaomi;
+    // Xiaomi Home has no fan_turn service and exposes the pad as four button
+    // entities instead, so all four buttons make the pad actionable on their own.
+    const hasNudgeButtons = Boolean(related.nudgeLeft) && Boolean(related.nudgeRight) && Boolean(related.nudgeUp) && Boolean(related.nudgeDown);
     return {
         isXiaomi,
         modelLabel: profile.label,
@@ -603,7 +606,7 @@ const detectCapabilities = (entity, services = { loaded: false, names: new Set()
             (hasVerticalAngle && customService(services, "fan_set_vertical_oscillation_angle")) ||
             (profile.verticalAngles.length > 0 && customService(services, "fan_set_vertical_oscillation_angle")),
         verticalAngles: profile.verticalAngles,
-        directionNudge: profile.supportsNudge && customService(services, "fan_turn"),
+        directionNudge: (profile.supportsNudge && customService(services, "fan_turn")) || hasNudgeButtons,
         naturalMode: presetMode &&
             (hasNaturalPreset ||
                 (!explicitFeatureMask &&
@@ -893,6 +896,10 @@ const RELATED_ENTITY_DOMAINS$1 = {
     led: ["switch", "input_boolean", "select", "number", "input_number"],
     buzzer: ["switch", "input_boolean", "select"],
     ionizer: ["switch", "input_boolean", "select"],
+    nudgeLeft: ["button"],
+    nudgeRight: ["button"],
+    nudgeUp: ["button"],
+    nudgeDown: ["button"],
     temperature: ["sensor"],
     humidity: ["sensor"],
 };
@@ -987,13 +994,21 @@ class StandardFanAdapter {
             "buzzer",
             "ionizer",
         ]);
+        // Momentary buttons report `unknown` until their first press, which would
+        // otherwise drop a fully working position pad.
+        const momentaryKeys = new Set([
+            "nudgeLeft",
+            "nudgeRight",
+            "nudgeUp",
+            "nudgeDown",
+        ]);
         for (const key of Object.keys(actionable)) {
             const entityId = actionable[key];
             const state = entityId ? this.hass.states[entityId] : undefined;
             const [domain] = entityId ? entityParts(entityId) : [""];
             if (!state ||
-                state.state === "unknown" ||
                 state.state === "unavailable" ||
+                (state.state === "unknown" && !momentaryKeys.has(key)) ||
                 !RELATED_ENTITY_DOMAINS$1[key].includes(domain) ||
                 ((key === "horizontalAngle" || key === "verticalAngle") &&
                     this.isSelectEntity(entityId) &&
@@ -1261,9 +1276,24 @@ class StandardFanAdapter {
         });
     }
     async nudge(direction) {
+        const button = this.nudgeButton(direction);
+        if (button) {
+            // Xiaomi Home exposes each pad direction as a momentary button entity.
+            await this.hass.callService("button", "press", { entity_id: button });
+            return;
+        }
         // Aiming the head only holds while the fan is not sweeping.
         await this.stopSwing();
         await this.callCustom("fan_turn", { direction });
+    }
+    nudgeButton(direction) {
+        const buttons = {
+            left: this.actionableRelated.nudgeLeft,
+            right: this.actionableRelated.nudgeRight,
+            up: this.actionableRelated.nudgeUp,
+            down: this.actionableRelated.nudgeDown,
+        };
+        return buttons[direction];
     }
     /**
      * An angle only takes effect on a sweeping axis, so selecting one implies
@@ -2963,6 +2993,10 @@ const suffixes = {
     led: ["_led", "_led_brightness", "_light"],
     buzzer: ["_buzzer", "_notification_sound"],
     ionizer: ["_anion", "_ionizer"],
+    nudgeLeft: ["_turn_left", "_move_left"],
+    nudgeRight: ["_turn_right", "_move_right"],
+    nudgeUp: ["_turn_upward", "_move_upward"],
+    nudgeDown: ["_turn_downward", "_move_downward"],
     temperature: ["_temperature"],
     humidity: ["_humidity"],
 };
@@ -3035,6 +3069,12 @@ const resolveRelatedEntities = async (hass, entityId) => {
         related.led = findBySuffix(entries, [...boolean, ...select, ...numeric], suffixes.led);
         related.buzzer = findBySuffix(entries, [...boolean, ...select], suffixes.buzzer);
         related.ionizer = findBySuffix(entries, [...boolean, ...select], suffixes.ionizer);
+        // Xiaomi Home exposes the position pad as momentary buttons whose ids end
+        // in a MIoT action suffix, so the hint fallback below does the matching.
+        related.nudgeLeft = findBySuffix(entries, ["button"], suffixes.nudgeLeft);
+        related.nudgeRight = findBySuffix(entries, ["button"], suffixes.nudgeRight);
+        related.nudgeUp = findBySuffix(entries, ["button"], suffixes.nudgeUp);
+        related.nudgeDown = findBySuffix(entries, ["button"], suffixes.nudgeDown);
         related.temperature = findSensorByDeviceClass(hass, entries, "temperature", suffixes.temperature);
         related.humidity = findSensorByDeviceClass(hass, entries, "humidity", suffixes.humidity);
         return related;

--- a/src/adapters/standard-fan.ts
+++ b/src/adapters/standard-fan.ts
@@ -66,6 +66,10 @@ const RELATED_ENTITY_DOMAINS: Record<keyof RelatedEntities, readonly string[]> =
   led: ["switch", "input_boolean", "select", "number", "input_number"],
   buzzer: ["switch", "input_boolean", "select"],
   ionizer: ["switch", "input_boolean", "select"],
+  nudgeLeft: ["button"],
+  nudgeRight: ["button"],
+  nudgeUp: ["button"],
+  nudgeDown: ["button"],
   temperature: ["sensor"],
   humidity: ["sensor"],
 };
@@ -192,6 +196,14 @@ export class StandardFanAdapter implements FanAdapter {
       "buzzer",
       "ionizer",
     ]);
+    // Momentary buttons report `unknown` until their first press, which would
+    // otherwise drop a fully working position pad.
+    const momentaryKeys: ReadonlySet<keyof RelatedEntities> = new Set([
+      "nudgeLeft",
+      "nudgeRight",
+      "nudgeUp",
+      "nudgeDown",
+    ]);
 
     for (const key of Object.keys(actionable) as Array<keyof RelatedEntities>) {
       const entityId = actionable[key];
@@ -199,8 +211,8 @@ export class StandardFanAdapter implements FanAdapter {
       const [domain] = entityId ? entityParts(entityId) : [""];
       if (
         !state ||
-        state.state === "unknown" ||
         state.state === "unavailable" ||
+        (state.state === "unknown" && !momentaryKeys.has(key)) ||
         !RELATED_ENTITY_DOMAINS[key].includes(domain) ||
         ((key === "horizontalAngle" || key === "verticalAngle") &&
           this.isSelectEntity(entityId) &&
@@ -536,9 +548,26 @@ export class StandardFanAdapter implements FanAdapter {
   }
 
   public async nudge(direction: "left" | "right" | "up" | "down"): Promise<void> {
+    const button = this.nudgeButton(direction);
+    if (button) {
+      // Xiaomi Home exposes each pad direction as a momentary button entity.
+      await this.hass.callService("button", "press", { entity_id: button });
+      return;
+    }
+
     // Aiming the head only holds while the fan is not sweeping.
     await this.stopSwing();
     await this.callCustom("fan_turn", { direction });
+  }
+
+  private nudgeButton(direction: "left" | "right" | "up" | "down"): string | undefined {
+    const buttons: Record<"left" | "right" | "up" | "down", string | undefined> = {
+      left: this.actionableRelated.nudgeLeft,
+      right: this.actionableRelated.nudgeRight,
+      up: this.actionableRelated.nudgeUp,
+      down: this.actionableRelated.nudgeDown,
+    };
+    return buttons[direction];
   }
 
   /**

--- a/src/state/capabilities.ts
+++ b/src/state/capabilities.ts
@@ -101,6 +101,10 @@ export const detectCapabilities = (
   const presetMode =
     hasFanFeature(entity, FAN_FEATURE_PRESET_MODE) || (!explicitFeatureMask && (hasPresetAttributes || profile.known));
   const xiaomiCustomModel = isXiaomi;
+  // Xiaomi Home has no fan_turn service and exposes the pad as four button
+  // entities instead, so all four buttons make the pad actionable on their own.
+  const hasNudgeButtons =
+    Boolean(related.nudgeLeft) && Boolean(related.nudgeRight) && Boolean(related.nudgeUp) && Boolean(related.nudgeDown);
   return {
     isXiaomi,
     modelLabel: profile.label,
@@ -148,7 +152,7 @@ export const detectCapabilities = (
       (hasVerticalAngle && customService(services, "fan_set_vertical_oscillation_angle")) ||
       (profile.verticalAngles.length > 0 && customService(services, "fan_set_vertical_oscillation_angle")),
     verticalAngles: profile.verticalAngles,
-    directionNudge: profile.supportsNudge && customService(services, "fan_turn"),
+    directionNudge: (profile.supportsNudge && customService(services, "fan_turn")) || hasNudgeButtons,
     naturalMode:
       presetMode &&
       (hasNaturalPreset ||

--- a/src/state/related-entities.ts
+++ b/src/state/related-entities.ts
@@ -21,6 +21,10 @@ const suffixes: Record<keyof RelatedEntities, string[]> = {
   led: ["_led", "_led_brightness", "_light"],
   buzzer: ["_buzzer", "_notification_sound"],
   ionizer: ["_anion", "_ionizer"],
+  nudgeLeft: ["_turn_left", "_move_left"],
+  nudgeRight: ["_turn_right", "_move_right"],
+  nudgeUp: ["_turn_upward", "_move_upward"],
+  nudgeDown: ["_turn_downward", "_move_downward"],
   temperature: ["_temperature"],
   humidity: ["_humidity"],
 };
@@ -115,6 +119,12 @@ export const resolveRelatedEntities = async (
     related.led = findBySuffix(entries, [...boolean, ...select, ...numeric], suffixes.led);
     related.buzzer = findBySuffix(entries, [...boolean, ...select], suffixes.buzzer);
     related.ionizer = findBySuffix(entries, [...boolean, ...select], suffixes.ionizer);
+    // Xiaomi Home exposes the position pad as momentary buttons whose ids end
+    // in a MIoT action suffix, so the hint fallback below does the matching.
+    related.nudgeLeft = findBySuffix(entries, ["button"], suffixes.nudgeLeft);
+    related.nudgeRight = findBySuffix(entries, ["button"], suffixes.nudgeRight);
+    related.nudgeUp = findBySuffix(entries, ["button"], suffixes.nudgeUp);
+    related.nudgeDown = findBySuffix(entries, ["button"], suffixes.nudgeDown);
     related.temperature = findSensorByDeviceClass(hass, entries, "temperature", suffixes.temperature);
     related.humidity = findSensorByDeviceClass(hass, entries, "humidity", suffixes.humidity);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,10 @@ export interface RelatedEntities {
   led?: string;
   buzzer?: string;
   ionizer?: string;
+  nudgeLeft?: string;
+  nudgeRight?: string;
+  nudgeUp?: string;
+  nudgeDown?: string;
   temperature?: string;
   humidity?: string;
 }

--- a/tests/fixtures/xiaomi-home-p76.ts
+++ b/tests/fixtures/xiaomi-home-p76.ts
@@ -1,0 +1,55 @@
+import type { HassLike } from "../../src/types";
+
+const registry = [
+  { entity_id: "fan.xiaomi_sg_000000000000_p76_s_2_fan", device_id: "device-xiaomi-home-p76" },
+  { entity_id: "button.xiaomi_sg_000000000000_p76_turn_left_a_2_4", device_id: "device-xiaomi-home-p76" },
+  { entity_id: "button.xiaomi_sg_000000000000_p76_turn_right_a_2_5", device_id: "device-xiaomi-home-p76" },
+  { entity_id: "button.xiaomi_sg_000000000000_p76_turn_upward_a_2_6", device_id: "device-xiaomi-home-p76" },
+  { entity_id: "button.xiaomi_sg_000000000000_p76_turn_downward_a_2_7", device_id: "device-xiaomi-home-p76" },
+];
+
+const services = {
+  fan: {
+    toggle: {},
+    turn_on: {},
+    turn_off: {},
+    set_percentage: {},
+    set_preset_mode: {},
+    oscillate: {},
+  },
+  button: {
+    press: {},
+  },
+};
+
+export const xiaomiHomeP76Hass = (): HassLike => ({
+  states: {
+    "fan.xiaomi_sg_000000000000_p76_s_2_fan": {
+      state: "on",
+      attributes: {
+        friendly_name: "Xiaomi Smart Fan",
+        model: "xiaomi.fan.p76",
+        percentage: 50,
+        preset_mode: "Level 2",
+        preset_modes: ["off", "Level 1", "Level 2", "Level 3", "Level 4", "Nature 1", "Nature 2"],
+      },
+    },
+    // Xiaomi Home action buttons stay `unknown` until their first press.
+    "button.xiaomi_sg_000000000000_p76_turn_left_a_2_4": { state: "unknown", attributes: {} },
+    "button.xiaomi_sg_000000000000_p76_turn_right_a_2_5": { state: "unknown", attributes: {} },
+    "button.xiaomi_sg_000000000000_p76_turn_upward_a_2_6": { state: "unknown", attributes: {} },
+    "button.xiaomi_sg_000000000000_p76_turn_downward_a_2_7": { state: "unknown", attributes: {} },
+  },
+  callService: () => undefined,
+  callWS: async <T>(message: Record<string, unknown>) => {
+    if (message.type === "config/entity_registry/list") {
+      return registry as T;
+    }
+
+    if (message.type === "get_services") {
+      return services as T;
+    }
+
+    return {} as T;
+  },
+});

--- a/tests/fixtures/xiaomi-home-p76.ts
+++ b/tests/fixtures/xiaomi-home-p76.ts
@@ -41,15 +41,6 @@ export const xiaomiHomeP76Hass = (): HassLike => ({
     "button.xiaomi_sg_000000000000_p76_turn_downward_a_2_7": { state: "unknown", attributes: {} },
   },
   callService: () => undefined,
-  callWS: async <T>(message: Record<string, unknown>) => {
-    if (message.type === "config/entity_registry/list") {
-      return registry as T;
-    }
-
-    if (message.type === "get_services") {
-      return services as T;
-    }
-
-    return {} as T;
-  },
+  callWS: async <T>(message: Record<string, unknown>) =>
+    message.type === "get_services" ? (services as T) : (registry as T),
 });

--- a/tests/unit/xiaomi-home-p76.test.ts
+++ b/tests/unit/xiaomi-home-p76.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { createFanAdapter } from "../../src/adapters";
+import { readServiceAvailability } from "../../src/services/service-dispatcher";
+import { detectCapabilities } from "../../src/state/capabilities";
+import { resolveRelatedEntities } from "../../src/state/related-entities";
+import { xiaomiHomeP76Hass } from "../fixtures/xiaomi-home-p76";
+
+describe("native Xiaomi Home P76", () => {
+  it("discovers the position pad buttons from their MIoT action ids", async () => {
+    const hass = xiaomiHomeP76Hass();
+
+    await expect(resolveRelatedEntities(hass, "fan.xiaomi_sg_000000000000_p76_s_2_fan")).resolves.toMatchObject({
+      nudgeLeft: "button.xiaomi_sg_000000000000_p76_turn_left_a_2_4",
+      nudgeRight: "button.xiaomi_sg_000000000000_p76_turn_right_a_2_5",
+      nudgeUp: "button.xiaomi_sg_000000000000_p76_turn_upward_a_2_6",
+      nudgeDown: "button.xiaomi_sg_000000000000_p76_turn_downward_a_2_7",
+    });
+  });
+
+  it("reports the pad as actionable without the fan_turn service", async () => {
+    const hass = xiaomiHomeP76Hass();
+    const services = readServiceAvailability({
+      fan: { turn_on: {}, turn_off: {}, set_percentage: {}, set_preset_mode: {} },
+      button: { press: {} },
+    });
+    const related = await resolveRelatedEntities(hass, "fan.xiaomi_sg_000000000000_p76_s_2_fan");
+    const capabilities = detectCapabilities(hass.states["fan.xiaomi_sg_000000000000_p76_s_2_fan"], services, related);
+
+    expect(capabilities.directionNudge).toBe(true);
+  });
+
+  it("keeps the pad hidden when only some directions exist", async () => {
+    const hass = xiaomiHomeP76Hass();
+    const related = await resolveRelatedEntities(hass, "fan.xiaomi_sg_000000000000_p76_s_2_fan");
+    const capabilities = detectCapabilities(hass.states["fan.xiaomi_sg_000000000000_p76_s_2_fan"], undefined, {
+      ...related,
+      nudgeDown: undefined,
+    });
+
+    expect(capabilities.directionNudge).toBe(false);
+  });
+
+  it("presses the matching button instead of a vendor service", async () => {
+    const hass = xiaomiHomeP76Hass();
+    const calls: unknown[][] = [];
+    hass.callService = (...args) => {
+      calls.push(args);
+    };
+    const services = readServiceAvailability({
+      fan: { turn_on: {}, turn_off: {}, set_percentage: {}, set_preset_mode: {} },
+      button: { press: {} },
+    });
+    const related = await resolveRelatedEntities(hass, "fan.xiaomi_sg_000000000000_p76_s_2_fan");
+    const adapter = createFanAdapter(hass, "fan.xiaomi_sg_000000000000_p76_s_2_fan", services, "auto", related);
+
+    expect(adapter.capabilities.directionNudge).toBe(true);
+
+    await adapter.nudge("up");
+    await adapter.nudge("left");
+
+    expect(calls).toEqual([
+      ["button", "press", { entity_id: "button.xiaomi_sg_000000000000_p76_turn_upward_a_2_6" }],
+      ["button", "press", { entity_id: "button.xiaomi_sg_000000000000_p76_turn_left_a_2_4" }],
+    ]);
+  });
+});

--- a/tests/unit/xiaomi-home-p76.test.ts
+++ b/tests/unit/xiaomi-home-p76.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createFanAdapter } from "../../src/adapters";
-import { readServiceAvailability } from "../../src/services/service-dispatcher";
+import { loadServiceAvailability, readServiceAvailability } from "../../src/services/service-dispatcher";
 import { detectCapabilities } from "../../src/state/capabilities";
 import { resolveRelatedEntities } from "../../src/state/related-entities";
 import { xiaomiHomeP76Hass } from "../fixtures/xiaomi-home-p76";
@@ -62,5 +62,25 @@ describe("native Xiaomi Home P76", () => {
       ["button", "press", { entity_id: "button.xiaomi_sg_000000000000_p76_turn_upward_a_2_6" }],
       ["button", "press", { entity_id: "button.xiaomi_sg_000000000000_p76_turn_left_a_2_4" }],
     ]);
+  });
+
+  it("reads the registered services through the device websocket", async () => {
+    const hass = xiaomiHomeP76Hass();
+    const availability = await loadServiceAvailability(hass);
+
+    expect(availability.loaded).toBe(true);
+    expect(availability.names.has("button.press")).toBe(true);
+  });
+
+  it("dispatches nudges through the fixture's no-op call service", async () => {
+    const hass = xiaomiHomeP76Hass();
+    const services = readServiceAvailability({
+      fan: { turn_on: {}, turn_off: {}, set_percentage: {}, set_preset_mode: {} },
+      button: { press: {} },
+    });
+    const related = await resolveRelatedEntities(hass, "fan.xiaomi_sg_000000000000_p76_s_2_fan");
+    const adapter = createFanAdapter(hass, "fan.xiaomi_sg_000000000000_p76_s_2_fan", services, "auto", related);
+
+    await expect(adapter.nudge("down")).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION
## Problem

Fixes #41

The position pad never appeared for a `xiaomi.fan.p76` fan on the native
Xiaomi Home integration, even with all four `turn_left`, `turn_right`,
`turn_upward`, and `turn_downward` button entities present.

## Root cause

The `directionNudge` capability required the `xiaomi_miio_fan.fan_turn`
service. Native Xiaomi Home does not register that service; it exposes the
pad as momentary button entities, which the card neither discovered nor
called.

## Change

- Discover the four turn buttons as related entities (exact suffix plus
  hint fallback, so MIoT action ids such as `..._turn_left_a_2_4` match).
- Treat all four buttons as sufficient evidence for `directionNudge`
  without any vendor service; a partial set keeps the pad hidden so no
  dead arrows are rendered.
- `adapter.nudge()` presses the matching button through `button.press`
  and only falls back to the `fan_turn` custom service otherwise.
- Momentary buttons report `unknown` until their first press, so they are
  no longer dropped as unavailable controls.
- README documents the button-based pad; `dist/xiaomi-fan-card.js` is
  rebuilt because HACS tracks the bundle.

## Testing

- New `tests/unit/xiaomi-home-p76.test.ts` (4 tests) with a redacted
  fixture mirroring the issue entity ids: button discovery, capability
  without `fan_turn`, partial set stays hidden, nudge presses `button.press`.
- Full `npm run validate`: format, lint, typecheck, coverage, and build
  all pass; 129/129 tests green.