### PR TITLE
fix(card): size sections grid to the rendered card height

### DIFF
--- a/dist/xiaomi-fan-card.js
+++ b/dist/xiaomi-fan-card.js
@@ -3123,8 +3123,10 @@ class XiaomiFanCard extends i$2 {
         return this.estimatedRows();
     }
     getGridOptions() {
-        const rows = this.estimatedRows();
-        return { columns: 12, rows, min_columns: 6, min_rows: Math.min(rows, 2) };
+        // A fixed row count would reserve grid cells for controls the card hides
+        // when a feature is disabled or unsupported, so the section keeps the empty
+        // space below the card. "auto" lets the grid follow the rendered height.
+        return { columns: 12, rows: "auto", min_columns: 6, min_rows: 1 };
     }
     setConfig(config) {
         const entity = config?.entity ?? config?.entity_id;
@@ -3367,17 +3369,22 @@ class XiaomiFanCard extends i$2 {
         const title = this.config.name || state.friendlyName;
         const modeLabel = state.mode === "natural" ? this.t("naturalBreeze") : this.t("straightAirflow");
         const status = state.isOn ? this.t("running") : this.t("standby");
+        // The eyebrow names a Xiaomi product line, so a generic fan entity must
+        // never claim it even when the full header is active.
+        const showEyebrow = this.config.header.show_eyebrow && adapter.capabilities.isXiaomi;
+        const showSubtitle = this.config.header.show_status || this.config.header.show_mode;
+        const showModel = this.config.header.show_model && adapter.profile.known;
+        // An empty header would still reserve its tap target and divider, so the
+        // block disappears completely once every header element is hidden.
+        if (!showEyebrow && !this.config.header.show_name && !showSubtitle && !showModel) {
+            return "";
+        }
         return b `
       <header class="header" style=${o(styleMapFor(this.config.styles.header, "fan-header"))}>
         <button class="title-button" @click=${this.onHeaderClick} aria-label=${this.t("open", { title })}>
-          ${
-        // The eyebrow names a Xiaomi product line, so a generic fan entity
-        // must never claim it even when the full header is active.
-        this.config.header.show_eyebrow && adapter.capabilities.isXiaomi
-            ? b `<span class="eyebrow">${this.t("xiaomiAirCirculation")}</span>`
-            : ""}
+          ${showEyebrow ? b `<span class="eyebrow">${this.t("xiaomiAirCirculation")}</span>` : ""}
           ${this.config.header.show_name ? b `<span class="title">${title}</span>` : ""}
-          ${this.config.header.show_status || this.config.header.show_mode
+          ${showSubtitle
             ? b `
                   <span class="subtitle">
                     ${this.config.header.show_status
@@ -3388,9 +3395,7 @@ class XiaomiFanCard extends i$2 {
                 `
             : ""}
         </button>
-        ${this.config.header.show_model && adapter.profile.known
-            ? b `<span class="model-badge">${adapter.profile.model?.split(".").at(-1) ?? "XIAOMI"}</span>`
-            : ""}
+        ${showModel ? b `<span class="model-badge">${adapter.profile.model?.split(".").at(-1) ?? "XIAOMI"}</span>` : ""}
       </header>
     `;
     }
@@ -3400,6 +3405,12 @@ class XiaomiFanCard extends i$2 {
         const style = `--speed:${speed}; --spin-duration:${Math.max(1.8, 12 - speed / 11)}s;`;
         const axis = getAirflowAxis(state.horizontalSwing, state.verticalSwing);
         const animationDisabled = this.config.disable_animation || this.config.visual.animation === "disabled";
+        const details = this.config.visual.show_details ? this.renderDetails(adapter) : "";
+        // An empty section would still add a block gap to the card, so the visual
+        // block disappears completely once the graphic and the details are gone.
+        if (!this.config.visual.show_graphic && details === "") {
+            return "";
+        }
         return b `
       <section
         class="visual-section details-${this.config.details.position} ${this.config.visual.show_graphic ? "details-with-graphic" : "details-only"}"
@@ -3450,7 +3461,7 @@ class XiaomiFanCard extends i$2 {
                 </div>
               `
             : ""}
-        ${this.config.visual.show_details ? this.renderDetails(adapter) : ""}
+        ${details}
       </section>
     `;
     }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -288,9 +288,11 @@ for a fan that reports presets but exposes no actionable oscillation or angle
 entity.
 
 The card reports its own size to Home Assistant. Masonry dashboards use
-`getCardSize`, and sections dashboards use `getGridOptions` with a
-twelve-column default whose row count follows the enabled header variant,
-graphic, and control groups.
+`getCardSize`, whose estimate follows the enabled header variant, graphic, and
+control groups. Sections dashboards use `getGridOptions` with a twelve-column
+default and automatic rows, so the grid cell matches the rendered height
+instead of reserving space for hidden or unsupported controls. Set
+`grid_options.rows` in the card configuration to pin a fixed height.
 
 The visual editor uses Home Assistant's native form schema. The fan and related
 entity fields therefore use Home Assistant entity selectors with domain filters,

--- a/src/card.ts
+++ b/src/card.ts
@@ -105,9 +105,11 @@ export class XiaomiFanCard extends LitElement {
     return this.estimatedRows();
   }
 
-  public getGridOptions(): { columns: number; rows: number; min_columns: number; min_rows: number } {
-    const rows = this.estimatedRows();
-    return { columns: 12, rows, min_columns: 6, min_rows: Math.min(rows, 2) };
+  public getGridOptions(): { columns: number; rows: "auto"; min_columns: number; min_rows: number } {
+    // A fixed row count would reserve grid cells for controls the card hides
+    // when a feature is disabled or unsupported, so the section keeps the empty
+    // space below the card. "auto" lets the grid follow the rendered height.
+    return { columns: 12, rows: "auto", min_columns: 6, min_rows: 1 };
   }
 
   public setConfig(config: FanCardConfig): void {
@@ -403,20 +405,25 @@ export class XiaomiFanCard extends LitElement {
     const title = this.config.name || state.friendlyName;
     const modeLabel = state.mode === "natural" ? this.t("naturalBreeze") : this.t("straightAirflow");
     const status = state.isOn ? this.t("running") : this.t("standby");
+    // The eyebrow names a Xiaomi product line, so a generic fan entity must
+    // never claim it even when the full header is active.
+    const showEyebrow = this.config.header.show_eyebrow && adapter.capabilities.isXiaomi;
+    const showSubtitle = this.config.header.show_status || this.config.header.show_mode;
+    const showModel = this.config.header.show_model && adapter.profile.known;
+
+    // An empty header would still reserve its tap target and divider, so the
+    // block disappears completely once every header element is hidden.
+    if (!showEyebrow && !this.config.header.show_name && !showSubtitle && !showModel) {
+      return "";
+    }
 
     return html`
       <header class="header" style=${styleMap(styleMapFor(this.config.styles.header, "fan-header"))}>
         <button class="title-button" @click=${this.onHeaderClick} aria-label=${this.t("open", { title })}>
-          ${
-            // The eyebrow names a Xiaomi product line, so a generic fan entity
-            // must never claim it even when the full header is active.
-            this.config.header.show_eyebrow && adapter.capabilities.isXiaomi
-              ? html`<span class="eyebrow">${this.t("xiaomiAirCirculation")}</span>`
-              : ""
-          }
+          ${showEyebrow ? html`<span class="eyebrow">${this.t("xiaomiAirCirculation")}</span>` : ""}
           ${this.config.header.show_name ? html`<span class="title">${title}</span>` : ""}
           ${
-            this.config.header.show_status || this.config.header.show_mode
+            showSubtitle
               ? html`
                   <span class="subtitle">
                     ${
@@ -430,11 +437,7 @@ export class XiaomiFanCard extends LitElement {
               : ""
           }
         </button>
-        ${
-          this.config.header.show_model && adapter.profile.known
-            ? html`<span class="model-badge">${adapter.profile.model?.split(".").at(-1) ?? "XIAOMI"}</span>`
-            : ""
-        }
+        ${showModel ? html`<span class="model-badge">${adapter.profile.model?.split(".").at(-1) ?? "XIAOMI"}</span>` : ""}
       </header>
     `;
   }
@@ -445,6 +448,13 @@ export class XiaomiFanCard extends LitElement {
     const style = `--speed:${speed}; --spin-duration:${Math.max(1.8, 12 - speed / 11)}s;`;
     const axis = getAirflowAxis(state.horizontalSwing, state.verticalSwing);
     const animationDisabled = this.config.disable_animation || this.config.visual.animation === "disabled";
+    const details = this.config.visual.show_details ? this.renderDetails(adapter) : "";
+
+    // An empty section would still add a block gap to the card, so the visual
+    // block disappears completely once the graphic and the details are gone.
+    if (!this.config.visual.show_graphic && details === "") {
+      return "";
+    }
 
     return html`
       <section
@@ -506,7 +516,7 @@ export class XiaomiFanCard extends LitElement {
               `
             : ""
         }
-        ${this.config.visual.show_details ? this.renderDetails(adapter) : ""}
+        ${details}
       </section>
     `;
   }

--- a/tests/component/card.test.ts
+++ b/tests/component/card.test.ts
@@ -3,6 +3,7 @@
 import type { HomeAssistant } from "custom-card-helpers";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { XiaomiFanCard } from "../../src/card";
+import { getModelProfile } from "../../src/state/model-profiles";
 import type { FanCardConfig, HassEntity, HassLike } from "../../src/types";
 
 const services = {
@@ -471,6 +472,47 @@ describe("XiaomiFanCard", () => {
     expect(card.shadowRoot?.querySelector(".title-button")).toBeNull();
   });
 
+  it("renders a name-only header without an empty subtitle", async () => {
+    const { card } = await renderCard({
+      ...baseConfig,
+      header: {
+        show: true,
+        show_eyebrow: false,
+        show_name: true,
+        show_status: false,
+        show_mode: false,
+        show_model: false,
+      },
+    });
+
+    expect(card.shadowRoot?.querySelector(".title")?.textContent).toBe("Test fan");
+    expect(card.shadowRoot?.querySelector(".subtitle")).toBeNull();
+  });
+
+  it("falls back when a known profile has no model identifier", async () => {
+    const profile = getModelProfile("xiaomi.fan.p76");
+    const model = profile.model;
+    profile.model = undefined;
+
+    try {
+      const { card } = await renderCard({
+        ...baseConfig,
+        header: {
+          show: true,
+          show_eyebrow: false,
+          show_name: false,
+          show_status: false,
+          show_mode: false,
+          show_model: true,
+        },
+      });
+
+      expect(card.shadowRoot?.querySelector(".model-badge")?.textContent).toBe("XIAOMI");
+    } finally {
+      profile.model = model;
+    }
+  });
+
   it("drops the visual block when the graphic and the details are hidden", async () => {
     const { card } = await renderCard({
       ...baseConfig,
@@ -479,6 +521,16 @@ describe("XiaomiFanCard", () => {
     });
 
     expect(card.shadowRoot?.querySelector(".visual-section")).toBeNull();
+  });
+
+  it("renders the graphic when details are disabled", async () => {
+    const { card } = await renderCard({
+      ...baseConfig,
+      visual: { show: true, show_graphic: true, show_details: false },
+    });
+
+    expect(card.shadowRoot?.querySelector(".visual-section.details-with-graphic")).toBeTruthy();
+    expect(card.shadowRoot?.querySelector(".visual-meta")).toBeNull();
   });
 
   it("keeps automatic section rows when features are disabled", async () => {

--- a/tests/component/card.test.ts
+++ b/tests/component/card.test.ts
@@ -280,7 +280,7 @@ describe("XiaomiFanCard", () => {
     const { card } = await renderCard({
       ...baseConfig,
       header: { show: true },
-      visual: { show: true, show_graphic: false, show_details: false },
+      visual: { show: true, show_graphic: false, show_details: true },
       controls: { ...baseConfig.controls, show_speed_levels: true },
       layout: { order: ["features", "visual", "header", "airflow", "position"] },
     });
@@ -448,10 +448,49 @@ describe("XiaomiFanCard", () => {
     expect(card.getCardSize()).toBeGreaterThan(4);
     expect(card.getGridOptions()).toEqual({
       columns: 12,
-      rows: card.getCardSize(),
+      rows: "auto",
       min_columns: 6,
-      min_rows: 2,
+      min_rows: 1,
     });
+  });
+
+  it("drops the header block when every header element is hidden", async () => {
+    const { card } = await renderCard({
+      ...baseConfig,
+      header: {
+        show: true,
+        show_eyebrow: false,
+        show_name: false,
+        show_status: false,
+        show_mode: false,
+        show_model: false,
+      },
+    });
+
+    expect(card.shadowRoot?.querySelector(".header")).toBeNull();
+    expect(card.shadowRoot?.querySelector(".title-button")).toBeNull();
+  });
+
+  it("drops the visual block when the graphic and the details are hidden", async () => {
+    const { card } = await renderCard({
+      ...baseConfig,
+      visual: { show: true, show_graphic: false, show_details: true },
+      details: { show: false },
+    });
+
+    expect(card.shadowRoot?.querySelector(".visual-section")).toBeNull();
+  });
+
+  it("keeps automatic section rows when features are disabled", async () => {
+    const { card } = await renderCard({
+      ...baseConfig,
+      header: { show: false },
+      visual: { show: false },
+      controls: { show: false },
+    });
+
+    // A hidden section must not reserve grid cells that stay empty below the card.
+    expect(card.getGridOptions().rows).toBe("auto");
   });
 
   const capabilityConfig: FanCardConfig = {


### PR DESCRIPTION
## Summary

Sections dashboards reserved grid rows from the card's estimated height, so disabled or unsupported features left empty space below the card. The grid now follows the rendered height instead.

## Changes

- `getGridOptions` returns `rows: "auto"` with `min_rows: 1` instead of the fixed `estimatedRows()` value, so the sections grid cell matches the rendered height and no longer reserves space for hidden controls. Users can still pin a fixed height with `grid_options.rows`.
- The header block disappears completely when every header element is hidden, instead of keeping its empty tap target and divider.
- The visual block disappears completely when both the graphic and the details are hidden, instead of adding a block gap.
- Rebuilt `dist/xiaomi-fan-card.js`.
- Updated `docs/configuration.md` for the new sizing behavior.

## Testing

- New unit tests: empty header block dropped, empty visual block dropped, grid rows stay automatic with all sections disabled.
- Updated existing tests for the new `getGridOptions` shape.

<!-- Test plan -->

- [x] Unit tests cover the new grid sizing and empty-section behavior
- [x] Bundle rebuilt via `npm run build`
- [ ] CI passes on this PR
