### PR TITLE
fix: support P76 Miot property controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ styles:
 | Auto detection   | `auto`             | Standard fan actions and related entity discovery. Vendor services are never guessed.                                                   |
 | Xiaomi Home      | `xiaomi_miio`      | Standard fan actions plus related switch, number, select, and sensor entities.                                                          |
 | syssi/xiaomi_fan | `xiaomi_miio_fan`  | Xiaomi services for angle, vertical oscillation, nudge, timer, LED, buzzer, child lock, and ionizer when supported by the target model. |
-| Xiaomi MIOT      | `xiaomi_miot`      | Standard fan actions plus actionable related entities exposed by Xiaomi MIoT.                                                           |
+| Xiaomi MIOT      | `xiaomi_miot`      | Standard actions, related entities, and verified P76 swing/angle properties via Xiaomi Miot services.                                   |
 | Any HA `fan`     | `standard`         | Percentage, presets, oscillation, direction, and whatever related entities exist.                                                       |
 
 `auto` and `standard` use public Home Assistant fan actions. Select
@@ -258,9 +258,10 @@ integration:
 - `xiaomi_miio_fan`: angle, vertical oscillation, nudge, timer, LED, buzzer,
   and child lock actions need both device support and registered
   `xiaomi_miio_fan.*` services. Service registration alone is not device support.
-- `xiaomi_miot`: angle and vertical controls appear only when Xiaomi MIoT
-  exposes actionable same-device related entities. Angle `select` entities
-  must provide numeric options such as `30`, `60°`, or `90 degrees`.
+- `xiaomi_miot`: actionable same-device related entities take precedence.
+  Angle `select` entities must provide numeric options such as `30`, `60°`,
+  or `90 degrees`. For `xiaomi.fan.p76`, exposed swing and angle properties
+  can also use the registered `xiaomi_miot.set_property` service.
 - `auto` and `standard`: the card uses standard fan actions and related
   entities. Primary angle attributes without a matching action remain hidden
   and do not create dead controls or details.
@@ -271,10 +272,30 @@ switches, input booleans, and selects can provide an optional control when the
 fan integration exposes it as a separate entity. The power button requires
 `TURN_OFF` while running and `TURN_ON` while stopped.
 
+For a P76 whose Xiaomi Miot integration puts these properties on its Info
+button instead of separate controls, select the integration explicitly:
+
+```yaml
+type: custom:xiaomi-fan-card
+entity: fan.example
+integration: xiaomi_miot
+```
+
+The card reads `fan.vertical_swing`, `horizontal_swing_included_angle-2-7`,
+and `vertical_swing_included_angle-2-9` from the primary fan or its same-device
+Xiaomi Miot Info entity. It writes the exact exposed field name through Home
+Assistant. No extra angle or vertical-swing entities are required when that
+service and valid property values exist. An Info button's `unknown` state
+does not make its available metadata unusable.
+
 The card does not connect directly to Xiaomi devices and does not invent
-MIoT property or service names. If MIoT exposes only read-only fan attributes,
-configure writable related entities in the integration or keep those controls
-hidden. Changing the card's integration setting does not create device actions.
+MIoT property or service names. A model name or `controls.show_*: true` alone
+cannot unlock controls. This property fallback is limited to the verified
+P76 model and explicit `xiaomi_miot` mode; `auto` and `standard` keep their
+standard action paths. If MIoT exposes only read-only fan attributes,
+configure writable related entities in the integration or keep those
+controls hidden. Changing the card's integration setting does not create
+device actions.
 
 ### Capability safety
 
@@ -524,7 +545,11 @@ intentionally hides that control. See
 [docs/compatibility.md](docs/compatibility.md).
 
 For `xiaomi_miot`, verify that the related entity exists, belongs to the same
-device, is available, and exposes the expected domain and options. Include the
+device, is available, and exposes the expected domain and options. For the P76
+property fallback, check `integration: xiaomi_miot`, the registered
+`xiaomi_miot.set_property` action, and valid properties on the fan or its
+same-device Xiaomi Miot Info entity. Include only the relevant redacted Info
+properties, not its full diagnostic attributes. Include the
 integration name, Home Assistant and HACS versions, browser, redacted primary
 entity state and attributes, redacted related entity domains, states, and
 options, registered service names, card configuration, console error, and exact

--- a/dist/xiaomi-fan-card.js
+++ b/dist/xiaomi-fan-card.js
@@ -655,6 +655,67 @@ const detectCapabilities = (entity, services = { loaded: false, names: new Set()
     };
 };
 
+const MIOT_FAN_PROPERTY_ATTRIBUTES = {
+    horizontalSwing: ["fan.horizontal_swing"],
+    horizontalAngle: ["fan.horizontal_swing_included_angle", "horizontal_swing_included_angle-2-7"],
+    verticalSwing: ["fan.vertical_swing"],
+    verticalAngle: ["fan.vertical_swing_included_angle", "vertical_swing_included_angle-2-9"],
+};
+const entityModel = (entity) => entity.attributes["model"] ?? entity.attributes["model_name"] ?? entity.attributes["miot_model"];
+const withMiotInfo = (entity, info) => {
+    if (!entity ||
+        !info ||
+        info.state === "unavailable" ||
+        info.attributes["available"] === false ||
+        typeof info.attributes["button.info"] !== "string") {
+        return entity;
+    }
+    const primaryModel = entityModel(entity);
+    const infoModel = entityModel(info);
+    if (primaryModel !== undefined && primaryModel !== infoModel) {
+        return entity;
+    }
+    const attributes = { ...entity.attributes };
+    if (primaryModel === undefined && typeof infoModel === "string") {
+        attributes["model"] = infoModel;
+    }
+    // Info carries device diagnostics too; only copy the fan fields we use.
+    for (const keys of Object.values(MIOT_FAN_PROPERTY_ATTRIBUTES)) {
+        for (const key of keys) {
+            if (!Object.prototype.hasOwnProperty.call(attributes, key) && info.attributes[key] !== undefined) {
+                attributes[key] = info.attributes[key];
+            }
+        }
+    }
+    return { ...entity, attributes };
+};
+const resolveMiotFanProperties = (entity) => {
+    if (!entity) {
+        return {};
+    }
+    const model = entityModel(entity);
+    const profile = getModelProfile(typeof model === "string" ? model : undefined);
+    // P76's spec confirms these properties are writable; other models need their own evidence.
+    if (profile.model !== "xiaomi.fan.p76") {
+        return {};
+    }
+    const properties = {};
+    for (const property of Object.keys(MIOT_FAN_PROPERTY_ATTRIBUTES)) {
+        const field = MIOT_FAN_PROPERTY_ATTRIBUTES[property].find((key) => {
+            const value = entity.attributes[key];
+            if (property === "horizontalSwing" || property === "verticalSwing") {
+                return typeof value === "boolean";
+            }
+            const angles = property === "horizontalAngle" ? profile.horizontalAngles : profile.verticalAngles;
+            return typeof value === "number" && angles.includes(value);
+        });
+        if (field !== undefined) {
+            properties[property] = field;
+        }
+    }
+    return properties;
+};
+
 const parseTimerUnit = (value) => {
     if (typeof value === "string" && ["s", "sec", "second", "seconds"].includes(value.trim().toLowerCase())) {
         return "s";
@@ -818,15 +879,27 @@ const normalizeFanState = (entityId, entity) => {
             "horizontal_oscillating",
             "horizontal_oscillation",
             "swing_mode",
+            ...MIOT_FAN_PROPERTY_ATTRIBUTES.horizontalSwing,
         ]),
         horizontalAngle: firstAngle(attributes, [
             "horizontal_swing_angle",
             "horizontal_angle",
             "swing_mode_angle",
             "angle",
+            ...MIOT_FAN_PROPERTY_ATTRIBUTES.horizontalAngle,
         ]),
-        verticalSwing: firstBoolean(attributes, ["vertical_swing", "vertical_oscillate", "vertical_oscillation"]),
-        verticalAngle: firstAngle(attributes, ["vertical_swing_angle", "vertical_oscillation_angle", "vertical_angle"]),
+        verticalSwing: firstBoolean(attributes, [
+            "vertical_swing",
+            "vertical_oscillate",
+            "vertical_oscillation",
+            ...MIOT_FAN_PROPERTY_ATTRIBUTES.verticalSwing,
+        ]),
+        verticalAngle: firstAngle(attributes, [
+            "vertical_swing_angle",
+            "vertical_oscillation_angle",
+            "vertical_angle",
+            ...MIOT_FAN_PROPERTY_ATTRIBUTES.verticalAngle,
+        ]),
         timerMinutes: timerMinutes(attributes, profile.timerUnit),
         childLock: booleanValue$1(attributes["child_lock"]),
         led: ledState(attributes),
@@ -903,6 +976,7 @@ const selectOptions = (entity) => {
     return Array.isArray(options) ? options.map(String) : [];
 };
 const RELATED_ENTITY_DOMAINS$1 = {
+    miotInfo: ["button"],
     sleepMode: ["switch", "input_boolean", "select"],
     horizontalSwing: ["switch", "input_boolean", "select"],
     verticalSwing: ["switch", "input_boolean", "select"],
@@ -972,18 +1046,19 @@ const booleanSelectOption = (options, enabled) => enabled
     ? selectOptionFor(options, BOOLEAN_SELECT_LABELS.enabledExact, BOOLEAN_SELECT_LABELS.enabledHints)
     : selectOptionFor(options, BOOLEAN_SELECT_LABELS.disabledExact, BOOLEAN_SELECT_LABELS.disabledHints);
 class StandardFanAdapter {
-    constructor(hass, entityId, services, related = {}) {
+    constructor(hass, entityId, services, related = {}, fanEntity = hass.states[entityId]) {
         this.hass = hass;
         this.entityId = entityId;
         this.services = services;
         this.related = related;
+        this.fanEntity = fanEntity;
         const actionableRelated = this.actionableRelatedEntities();
         this.actionableRelated = actionableRelated;
         const timerSpec = this.readTimerSpec(actionableRelated.timer);
         const timerUnit = this.readTimerUnit(actionableRelated.timer);
         this.state = normalizeFanState(entityId, this.entityWithRelatedAttributes(this.stateRelatedEntities(actionableRelated), timerSpec, timerUnit));
         this.profile = getModelProfile(this.state.model);
-        const detectedCapabilities = detectCapabilities(hass.states[entityId], services, actionableRelated);
+        const detectedCapabilities = detectCapabilities(this.fanEntity, services, actionableRelated);
         this.capabilities = {
             ...detectedCapabilities,
             horizontalAngles: this.readAngleOptions(actionableRelated.horizontalAngle) ??
@@ -1108,13 +1183,19 @@ class StandardFanAdapter {
         return rawSteps(spec).map((value) => roundStep(timerValueToMinutes(value, spec.unit)));
     }
     entityWithRelatedAttributes(related, timerSpec, timerUnit) {
-        const entity = this.hass.states[this.entityId];
+        const entity = this.fanEntity;
         if (!entity) {
             return undefined;
         }
         const attributes = { ...entity.attributes };
         const attributeAliases = {
-            horizontalAngle: ["horizontal_swing_angle", "horizontal_angle", "swing_mode_angle", "angle"],
+            horizontalAngle: [
+                "horizontal_swing_angle",
+                "horizontal_angle",
+                "swing_mode_angle",
+                "angle",
+                ...MIOT_FAN_PROPERTY_ATTRIBUTES.horizontalAngle,
+            ],
             horizontalSwing: [
                 "oscillating",
                 "oscillate",
@@ -1122,10 +1203,21 @@ class StandardFanAdapter {
                 "horizontal_oscillating",
                 "horizontal_oscillation",
                 "swing_mode",
+                ...MIOT_FAN_PROPERTY_ATTRIBUTES.horizontalSwing,
             ],
             favoriteLevel: ["favorite_level", "favorite_speed"],
-            verticalAngle: ["vertical_swing_angle", "vertical_oscillation_angle", "vertical_angle"],
-            verticalSwing: ["vertical_swing", "vertical_oscillate", "vertical_oscillation"],
+            verticalAngle: [
+                "vertical_swing_angle",
+                "vertical_oscillation_angle",
+                "vertical_angle",
+                ...MIOT_FAN_PROPERTY_ATTRIBUTES.verticalAngle,
+            ],
+            verticalSwing: [
+                "vertical_swing",
+                "vertical_oscillate",
+                "vertical_oscillation",
+                ...MIOT_FAN_PROPERTY_ATTRIBUTES.verticalSwing,
+            ],
             timer: ["delay_off_countdown", "delay_time", "power_off_time", "timer", "timer_unit", "delay_time_unit"],
             led: ["led", "light", "led_brightness", "light_enum"],
             buzzer: ["buzzer", "notification_sound"],
@@ -1550,6 +1642,82 @@ class XiaomiMiioFanAdapter extends StandardFanAdapter {
     }
 }
 
+class XiaomiMiotFanAdapter extends StandardFanAdapter {
+    constructor(hass, entityId, services, related = {}) {
+        super(hass, entityId, services, related, withMiotInfo(hass.states[entityId], related.miotInfo ? hass.states[related.miotInfo] : undefined));
+        this.standardHorizontalSwing = this.capabilities.horizontalSwing;
+        this.properties =
+            this.state.available && services.loaded && services.names.has("xiaomi_miot.set_property")
+                ? resolveMiotFanProperties(this.fanEntity)
+                : {};
+        for (const property of Object.keys(this.properties)) {
+            this.capabilities[property] = true;
+            if (!this.actionableRelated[property] && this.state[property] === undefined) {
+                // An unavailable related entity must not erase a working property fallback.
+                const value = this.fanEntity?.attributes[this.properties[property]];
+                if (property === "horizontalSwing" || property === "verticalSwing") {
+                    if (typeof value === "boolean")
+                        this.state[property] = value;
+                }
+                else if (typeof value === "number") {
+                    this.state[property] = value;
+                }
+            }
+        }
+    }
+    async setHorizontalSwing(enabled) {
+        if (this.standardHorizontalSwing) {
+            await super.setHorizontalSwing(enabled);
+            return;
+        }
+        await this.setProperty("horizontalSwing", enabled);
+    }
+    async setVerticalSwing(enabled) {
+        if (this.actionableRelated.verticalSwing) {
+            await super.setVerticalSwing(enabled);
+            return;
+        }
+        await this.setProperty("verticalSwing", enabled);
+    }
+    async setHorizontalAngle(angle) {
+        if (this.actionableRelated.horizontalAngle) {
+            await super.setHorizontalAngle(angle);
+            return;
+        }
+        await this.setAngle("horizontal", angle);
+    }
+    async setVerticalAngle(angle) {
+        if (this.actionableRelated.verticalAngle) {
+            await super.setVerticalAngle(angle);
+            return;
+        }
+        await this.setAngle("vertical", angle);
+    }
+    propertyField(property) {
+        const field = this.properties[property];
+        if (field === undefined) {
+            throw new Error(`This fan does not expose a writable Xiaomi Miot ${property} property.`);
+        }
+        return field;
+    }
+    async setAngle(axis, angle) {
+        const property = axis === "horizontal" ? "horizontalAngle" : "verticalAngle";
+        this.propertyField(property);
+        const angles = axis === "horizontal" ? this.profile.horizontalAngles : this.profile.verticalAngles;
+        if (!angles.includes(angle)) {
+            throw new Error(`Unsupported Xiaomi Miot ${axis} angle.`);
+        }
+        await this.startSwing(axis);
+        await this.setProperty(property, angle);
+    }
+    async setProperty(property, value) {
+        const field = this.propertyField(property);
+        if (!(await this.dispatcher.custom("xiaomi_miot", "set_property", { field, value }))) {
+            throw new Error("xiaomi_miot.set_property is unavailable.");
+        }
+    }
+}
+
 const createFanAdapter = (hass, entityId, services, integration = "auto", related = {}) => {
     const useXiaomiAdapter = integration === "xiaomi_miio" || integration === "xiaomi_miio_fan";
     const scopedServices = integration === "xiaomi_miio_fan" || (integration === "auto" && useXiaomiAdapter)
@@ -1558,6 +1726,9 @@ const createFanAdapter = (hass, entityId, services, integration = "auto", relate
             loaded: services.loaded,
             names: new Set([...services.names].filter((name) => !name.startsWith("xiaomi_miio_fan."))),
         };
+    if (integration === "xiaomi_miot") {
+        return new XiaomiMiotFanAdapter(hass, entityId, scopedServices, related);
+    }
     return useXiaomiAdapter
         ? new XiaomiMiioFanAdapter(hass, entityId, scopedServices, related, integration === "xiaomi_miio")
         : new StandardFanAdapter(hass, entityId, scopedServices, related);
@@ -3031,6 +3202,7 @@ if (!customElements.get("xiaomi-fan-card-editor")) {
 }
 
 const suffixes = {
+    miotInfo: [],
     sleepMode: ["_sleep_mode"],
     horizontalSwing: ["_oscillating", "_oscillate", "_horizontal_swing", "_horizontal_oscillation", "_swing_mode"],
     verticalSwing: ["_vertical_swing", "_vertical_oscillate", "_vertical_oscillating", "_vertical_oscillation"],
@@ -3107,6 +3279,11 @@ const resolveRelatedEntities = async (hass, entityId) => {
         }
         const entries = registry.filter((entry) => entry.device_id === primary.device_id);
         const related = {};
+        if (primary.platform === "xiaomi_miot") {
+            related.miotInfo = entries.find((entry) => entry.platform === "xiaomi_miot" &&
+                entry.entity_id.startsWith("button.") &&
+                typeof hass.states[entry.entity_id]?.attributes["button.info"] === "string")?.entity_id;
+        }
         const numeric = ["number", "input_number"];
         const angle = [...numeric, "select"];
         const boolean = ["switch", "input_boolean"];

--- a/dist/xiaomi-fan-card.js
+++ b/dist/xiaomi-fan-card.js
@@ -1656,11 +1656,10 @@ class XiaomiMiotFanAdapter extends StandardFanAdapter {
                 // An unavailable related entity must not erase a working property fallback.
                 const value = this.fanEntity?.attributes[this.properties[property]];
                 if (property === "horizontalSwing" || property === "verticalSwing") {
-                    if (typeof value === "boolean")
-                        this.state[property] = value;
+                    this.state[property] = booleanValue$1(value);
                 }
-                else if (typeof value === "number") {
-                    this.state[property] = value;
+                else {
+                    this.state[property] = numericLabel(value);
                 }
             }
         }

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -71,20 +71,42 @@ integer minutes for every model, including ZA5. Normal/natural mode falls back
 to custom services when the live presets only represent speed levels.
 The 2 Lite's Sleep preset can also be cleared through its normal-mode service.
 
-### Xiaomi Miot and other standard entities
+### Xiaomi Miot
 
 Use `integration: xiaomi_miot` or `integration: standard` when the integration
 exposes a normal Home Assistant `fan` entity. Configure `related_entities`
 when automatic entity discovery cannot identify an optional control. MIoT
 derives standard speed, presets, and oscillation from property converters.
-Optional angle controls require a discovered or configured related `select`,
-`number`, or `input_number` entity with numeric angle options. Primary fan
-attributes and raw MIoT property metadata alone are not treated as actions.
+Actionable related entities take precedence, and angle controls accept a
+discovered or configured related `select`, `number`, or `input_number` entity
+with numeric angle options.
 
 Default P76 converters expose an LED `light`, alarm and child-lock switches,
-and left/right buttons. Timer, angle, and vertical controls depend on additional
-entity exposure or customization. Raw MIoT services do not create a fallback
-in this card.
+and left/right buttons. Timer, angle, and vertical controls depend on
+additional entity exposure, customization, or the P76 property fallback below.
+
+For `xiaomi.fan.p76`, the card also supports writable swing and angle
+properties when `xiaomi_miot.set_property` is registered. Values can be on
+the primary fan or a Xiaomi Miot Info button sharing its registry device ID.
+The Info button can report `unknown` until pressed; its available metadata
+still works. Other devices' Info entities and unavailable metadata are ignored.
+
+Supported fields are `fan.horizontal_swing`, `fan.vertical_swing`,
+`horizontal_swing_included_angle-2-7`, and
+`vertical_swing_included_angle-2-9`. Fully qualified
+`fan.horizontal_swing_included_angle` and
+`fan.vertical_swing_included_angle` names work when exposed instead. Writes
+use the exact available field, not inferred property IDs. P76 angle options
+are `30`, `60`, `90`, `120` horizontally and `30`, `60`, `90`, `100` vertically.
+
+The property must exist with a valid boolean or allowed numeric angle.
+The model alone is insufficient, and this fallback is not enabled in `auto`,
+`standard`, `xiaomi_miio`, or `xiaomi_miio_fan`.
+
+The writable fields and angle options follow the
+[P76 MIoT specification](https://home.miot-spec.com/spec/xiaomi.fan.p76).
+Commands use the integration's
+[`set_property` service](https://github.com/al-one/hass-xiaomi-miot/blob/master/custom_components/xiaomi_miot/services.yaml).
 
 The `controls.show_horizontal_*` and `controls.show_vertical_*` options are
 visibility switches, not capability overrides. See
@@ -96,11 +118,11 @@ control visibility contract.
 The same device reaches these controls through a different path depending on
 the selected integration:
 
-| `integration`        | Vertical and angle behavior                                                              |
-| -------------------- | ---------------------------------------------------------------------------------------- |
-| `xiaomi_miio_fan`    | Uses model-supported `xiaomi_miio_fan.*` actions and verified profile ranges.            |
-| `xiaomi_miot`        | Uses standard fan actions plus same-device related switch/select/number entities.        |
-| `auto` or `standard` | Uses standard fan actions and related entities; does not invent vendor-specific actions. |
+| `integration`        | Vertical and angle behavior                                                                |
+| -------------------- | ------------------------------------------------------------------------------------------ |
+| `xiaomi_miio_fan`    | Uses model-supported `xiaomi_miio_fan.*` actions and verified profile ranges.              |
+| `xiaomi_miot`        | Uses related entities first, then verified P76 properties with `xiaomi_miot.set_property`. |
+| `auto` or `standard` | Uses standard fan actions and related entities; does not invent vendor-specific actions.   |
 
 When an integration exposes vertical or angle values as read-only attributes
 without a matching action entity or service, the card hides those controls.
@@ -166,6 +188,8 @@ Include:
 - Browser and frontend version
 - Integration name and fan model string
 - Redacted fan attributes and related entity domains and states
+- For the P76 property fallback, relevant redacted Info properties and whether
+  the Info entity belongs to the same Xiaomi Miot device
 - Related entity options, numeric ranges, units, and whether each entity
   shares the primary fan device ID
 - Card configuration

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -89,19 +89,29 @@ related_entities:
 
 ## Integration action paths
 
-| `integration`     | Action path                                                                                    |
-| ----------------- | ---------------------------------------------------------------------------------------------- |
-| `auto`            | Standard Home Assistant fan actions and related entity discovery.                              |
-| `standard`        | Standard Home Assistant fan actions and related entity discovery.                              |
-| `xiaomi_miio`     | Standard fan actions plus related Xiaomi Home entities.                                        |
-| `xiaomi_miio_fan` | Standard fan actions plus registered `xiaomi_miio_fan.*` services for model-specific controls. |
-| `xiaomi_miot`     | Standard fan actions plus actionable related entities exposed by Xiaomi MIoT.                  |
+| `integration`     | Action path                                                                                     |
+| ----------------- | ----------------------------------------------------------------------------------------------- |
+| `auto`            | Standard Home Assistant fan actions and related entity discovery.                               |
+| `standard`        | Standard Home Assistant fan actions and related entity discovery.                               |
+| `xiaomi_miio`     | Standard fan actions plus related Xiaomi Home entities.                                         |
+| `xiaomi_miio_fan` | Standard fan actions plus registered `xiaomi_miio_fan.*` services for model-specific controls.  |
+| `xiaomi_miot`     | Standard actions, related entities, and verified P76 properties via `xiaomi_miot.set_property`. |
 
 The card never calls a Xiaomi device directly. `auto` does not guess a vendor
 adapter. Select `xiaomi_miio_fan` only when the service registry contains the
 custom services required by the configured controls. A registered service alone
 does not prove that a model supports it; optional controls also need device
 attributes, a verified model profile, or actionable related entities.
+
+Select `xiaomi_miot` explicitly for the P76 property fallback:
+
+```yaml
+type: custom:xiaomi-fan-card
+entity: fan.example
+integration: xiaomi_miot
+```
+
+`auto` and `standard` do not opt into Xiaomi Miot property services.
 
 ## Legacy top-level related-entity aliases
 
@@ -259,11 +269,25 @@ Angle `number` and `input_number` entities use their own `min`, `max`, and
 `step`. A range short enough for a dropdown becomes a preset list, and a wider
 range keeps a numeric input bounded by the same values.
 
-For Xiaomi MIOT, angle and vertical controls require an actionable related
-entity. A primary fan angle attribute alone is not displayed as a detail and
-does not authorize an angle action. Vertical swing accepts `switch`,
-`input_boolean`, or `select`; angle controls accept `number`, `input_number`,
-or numeric-option `select`.
+For Xiaomi Miot, actionable related entities take precedence. Vertical swing
+accepts `switch`, `input_boolean`, or `select`; angle controls accept `number`,
+`input_number`, or numeric-option `select`.
+
+With `integration: xiaomi_miot`, `xiaomi.fan.p76` can fall back to
+`xiaomi_miot.set_property` when the service is registered and the primary fan
+or its same-device Xiaomi Miot Info button exposes valid swing/angle values.
+Discovery identifies Info by its `button.info` attribute and registry
+integration, not its translated entity name. No extra configuration field
+is required, and an `unknown` Info button state does not block available metadata.
+
+Supported properties are `fan.horizontal_swing`, `fan.vertical_swing`,
+`horizontal_swing_included_angle-2-7`, and
+`vertical_swing_included_angle-2-9`. Fully qualified
+`fan.horizontal_swing_included_angle` and
+`fan.vertical_swing_included_angle` aliases are also accepted when exposed.
+The exact field name is sent to Home Assistant. Horizontal angle options are
+`30`, `60`, `90`, `120`; vertical options are `30`, `60`, `90`, `100`.
+The model or a visibility flag alone never authorizes a property write.
 
 When a standard fan exposes `supported_features`, the feature mask is the
 source of truth for power, percentage, preset, oscillation, and direction support.
@@ -330,9 +354,8 @@ service payload. An exposed related timer entity takes precedence and uses its
 own declared unit. See the [verified contracts](integration-contracts.md) for
 the pinned sources and unresolved upstream unit ambiguities.
 
-MIoT optional angle controls require discovered or configured related `select`,
-`number`, or `input_number` entities. Primary MIoT fan attributes alone are
-not treated as angle actions.
+MIoT optional angles use related entities or the verified P76 property
+fallback described above. Other raw model attributes do not authorize writes.
 
 For Xiaomi LED brightness controls, the custom Xiaomi service contract is
 `0` for bright, `1` for dim, and `2` for off. A related

--- a/docs/integration-contracts.md
+++ b/docs/integration-contracts.md
@@ -240,8 +240,11 @@ The integration exposes global raw services:
 - `set_miot_property`: `{siid, piid, value}`
 
 Their existence is not writable-property evidence. Card behavior stays behind
-discovered or configured related entities and does not add a raw MIoT fallback.
-Automatic discovery is restricted to the primary fan's device.
+discovered or configured related entities, with one documented exception: the
+verified `xiaomi.fan.p76` swing and angle property fallback behind
+`xiaomi_miot.set_property` in explicit `integration: xiaomi_miot` mode (see
+[compatibility](compatibility.md)). Automatic discovery is restricted to the
+primary fan's device.
 
 Evidence:
 

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,5 +1,6 @@
 import { StandardFanAdapter } from "./standard-fan";
 import { XiaomiMiioFanAdapter } from "./xiaomi-miio-fan";
+import { XiaomiMiotFanAdapter } from "./xiaomi-miot-fan";
 import type { FanAdapter, FanCardConfig, HassLike, RelatedEntities, ServiceAvailability } from "../types";
 
 export const createFanAdapter = (
@@ -17,6 +18,10 @@ export const createFanAdapter = (
           loaded: services.loaded,
           names: new Set([...services.names].filter((name) => !name.startsWith("xiaomi_miio_fan."))),
         };
+
+  if (integration === "xiaomi_miot") {
+    return new XiaomiMiotFanAdapter(hass, entityId, scopedServices, related);
+  }
 
   return useXiaomiAdapter
     ? new XiaomiMiioFanAdapter(hass, entityId, scopedServices, related, integration === "xiaomi_miio")

--- a/src/adapters/standard-fan.ts
+++ b/src/adapters/standard-fan.ts
@@ -1,5 +1,6 @@
 import { detectCapabilities } from "../state/capabilities";
 import { getModelProfile } from "../state/model-profiles";
+import { MIOT_FAN_PROPERTY_ATTRIBUTES } from "../state/miot-properties";
 import {
   minutesToTimerValue,
   normalizeFanState,
@@ -56,6 +57,7 @@ const selectOptions = (entity: HassEntity | undefined): string[] => {
 };
 
 const RELATED_ENTITY_DOMAINS: Record<keyof RelatedEntities, readonly string[]> = {
+  miotInfo: ["button"],
   sleepMode: ["switch", "input_boolean", "select"],
   horizontalSwing: ["switch", "input_boolean", "select"],
   verticalSwing: ["switch", "input_boolean", "select"],
@@ -148,13 +150,14 @@ export class StandardFanAdapter implements FanAdapter {
   public readonly capabilities: FanCapabilities;
 
   protected readonly dispatcher: ServiceDispatcher;
-  private readonly actionableRelated: RelatedEntities;
+  protected readonly actionableRelated: RelatedEntities;
 
   constructor(
     protected readonly hass: HassLike,
     protected readonly entityId: string,
     protected readonly services: ServiceAvailability,
     protected readonly related: RelatedEntities = {},
+    protected readonly fanEntity: HassEntity | undefined = hass.states[entityId],
   ) {
     const actionableRelated = this.actionableRelatedEntities();
     this.actionableRelated = actionableRelated;
@@ -165,7 +168,7 @@ export class StandardFanAdapter implements FanAdapter {
       this.entityWithRelatedAttributes(this.stateRelatedEntities(actionableRelated), timerSpec, timerUnit),
     );
     this.profile = getModelProfile(this.state.model);
-    const detectedCapabilities = detectCapabilities(hass.states[entityId], services, actionableRelated);
+    const detectedCapabilities = detectCapabilities(this.fanEntity, services, actionableRelated);
     this.capabilities = {
       ...detectedCapabilities,
       horizontalAngles:
@@ -322,14 +325,20 @@ export class StandardFanAdapter implements FanAdapter {
     timerSpec: TimerSpec | undefined,
     timerUnit: TimerSpec["unit"],
   ): HassEntity | undefined {
-    const entity = this.hass.states[this.entityId];
+    const entity = this.fanEntity;
     if (!entity) {
       return undefined;
     }
 
     const attributes = { ...entity.attributes };
     const attributeAliases: Partial<Record<keyof RelatedEntities, readonly string[]>> = {
-      horizontalAngle: ["horizontal_swing_angle", "horizontal_angle", "swing_mode_angle", "angle"],
+      horizontalAngle: [
+        "horizontal_swing_angle",
+        "horizontal_angle",
+        "swing_mode_angle",
+        "angle",
+        ...MIOT_FAN_PROPERTY_ATTRIBUTES.horizontalAngle,
+      ],
       horizontalSwing: [
         "oscillating",
         "oscillate",
@@ -337,10 +346,21 @@ export class StandardFanAdapter implements FanAdapter {
         "horizontal_oscillating",
         "horizontal_oscillation",
         "swing_mode",
+        ...MIOT_FAN_PROPERTY_ATTRIBUTES.horizontalSwing,
       ],
       favoriteLevel: ["favorite_level", "favorite_speed"],
-      verticalAngle: ["vertical_swing_angle", "vertical_oscillation_angle", "vertical_angle"],
-      verticalSwing: ["vertical_swing", "vertical_oscillate", "vertical_oscillation"],
+      verticalAngle: [
+        "vertical_swing_angle",
+        "vertical_oscillation_angle",
+        "vertical_angle",
+        ...MIOT_FAN_PROPERTY_ATTRIBUTES.verticalAngle,
+      ],
+      verticalSwing: [
+        "vertical_swing",
+        "vertical_oscillate",
+        "vertical_oscillation",
+        ...MIOT_FAN_PROPERTY_ATTRIBUTES.verticalSwing,
+      ],
       timer: ["delay_off_countdown", "delay_time", "power_off_time", "timer", "timer_unit", "delay_time_unit"],
       led: ["led", "light", "led_brightness", "light_enum"],
       buzzer: ["buzzer", "notification_sound"],
@@ -583,7 +603,7 @@ export class StandardFanAdapter implements FanAdapter {
    * An angle only takes effect on a sweeping axis, so selecting one implies
    * starting that axis. An unknown swing state is left alone.
    */
-  private async startSwing(axis: "horizontal" | "vertical"): Promise<void> {
+  protected async startSwing(axis: "horizontal" | "vertical"): Promise<void> {
     if (axis === "horizontal") {
       if (this.capabilities.horizontalSwing && this.state.horizontalSwing === false) {
         await this.setHorizontalSwing(true);

--- a/src/adapters/xiaomi-miot-fan.ts
+++ b/src/adapters/xiaomi-miot-fan.ts
@@ -1,0 +1,99 @@
+import { StandardFanAdapter } from "./standard-fan";
+import { resolveMiotFanProperties, withMiotInfo } from "../state/miot-properties";
+import type { MiotFanProperties, MiotFanProperty } from "../state/miot-properties";
+import type { HassLike, RelatedEntities, ServiceAvailability } from "../types";
+
+export class XiaomiMiotFanAdapter extends StandardFanAdapter {
+  private readonly properties: MiotFanProperties;
+  private readonly standardHorizontalSwing: boolean;
+
+  constructor(hass: HassLike, entityId: string, services: ServiceAvailability, related: RelatedEntities = {}) {
+    super(
+      hass,
+      entityId,
+      services,
+      related,
+      withMiotInfo(hass.states[entityId], related.miotInfo ? hass.states[related.miotInfo] : undefined),
+    );
+    this.standardHorizontalSwing = this.capabilities.horizontalSwing;
+    this.properties =
+      this.state.available && services.loaded && services.names.has("xiaomi_miot.set_property")
+        ? resolveMiotFanProperties(this.fanEntity)
+        : {};
+    for (const property of Object.keys(this.properties) as MiotFanProperty[]) {
+      this.capabilities[property] = true;
+      if (!this.actionableRelated[property] && this.state[property] === undefined) {
+        // An unavailable related entity must not erase a working property fallback.
+        const value = this.fanEntity?.attributes[this.properties[property]!];
+        if (property === "horizontalSwing" || property === "verticalSwing") {
+          if (typeof value === "boolean") this.state[property] = value;
+        } else if (typeof value === "number") {
+          this.state[property] = value;
+        }
+      }
+    }
+  }
+
+  public override async setHorizontalSwing(enabled: boolean): Promise<void> {
+    if (this.standardHorizontalSwing) {
+      await super.setHorizontalSwing(enabled);
+      return;
+    }
+
+    await this.setProperty("horizontalSwing", enabled);
+  }
+
+  public override async setVerticalSwing(enabled: boolean): Promise<void> {
+    if (this.actionableRelated.verticalSwing) {
+      await super.setVerticalSwing(enabled);
+      return;
+    }
+
+    await this.setProperty("verticalSwing", enabled);
+  }
+
+  public override async setHorizontalAngle(angle: number): Promise<void> {
+    if (this.actionableRelated.horizontalAngle) {
+      await super.setHorizontalAngle(angle);
+      return;
+    }
+
+    await this.setAngle("horizontal", angle);
+  }
+
+  public override async setVerticalAngle(angle: number): Promise<void> {
+    if (this.actionableRelated.verticalAngle) {
+      await super.setVerticalAngle(angle);
+      return;
+    }
+
+    await this.setAngle("vertical", angle);
+  }
+
+  private propertyField(property: MiotFanProperty): string {
+    const field = this.properties[property];
+    if (field === undefined) {
+      throw new Error(`This fan does not expose a writable Xiaomi Miot ${property} property.`);
+    }
+    return field;
+  }
+
+  private async setAngle(axis: "horizontal" | "vertical", angle: number): Promise<void> {
+    const property = axis === "horizontal" ? "horizontalAngle" : "verticalAngle";
+    this.propertyField(property);
+    const angles = axis === "horizontal" ? this.profile.horizontalAngles : this.profile.verticalAngles;
+    if (!angles.includes(angle)) {
+      throw new Error(`Unsupported Xiaomi Miot ${axis} angle.`);
+    }
+
+    await this.startSwing(axis);
+    await this.setProperty(property, angle);
+  }
+
+  private async setProperty(property: MiotFanProperty, value: boolean | number): Promise<void> {
+    const field = this.propertyField(property);
+    if (!(await this.dispatcher.custom("xiaomi_miot", "set_property", { field, value }))) {
+      throw new Error("xiaomi_miot.set_property is unavailable.");
+    }
+  }
+}

--- a/src/adapters/xiaomi-miot-fan.ts
+++ b/src/adapters/xiaomi-miot-fan.ts
@@ -1,6 +1,7 @@
 import { StandardFanAdapter } from "./standard-fan";
 import { resolveMiotFanProperties, withMiotInfo } from "../state/miot-properties";
 import type { MiotFanProperties, MiotFanProperty } from "../state/miot-properties";
+import { booleanValue, numericLabel } from "../state/normalize-state";
 import type { HassLike, RelatedEntities, ServiceAvailability } from "../types";
 
 export class XiaomiMiotFanAdapter extends StandardFanAdapter {
@@ -26,9 +27,9 @@ export class XiaomiMiotFanAdapter extends StandardFanAdapter {
         // An unavailable related entity must not erase a working property fallback.
         const value = this.fanEntity?.attributes[this.properties[property]!];
         if (property === "horizontalSwing" || property === "verticalSwing") {
-          if (typeof value === "boolean") this.state[property] = value;
-        } else if (typeof value === "number") {
-          this.state[property] = value;
+          this.state[property] = booleanValue(value);
+        } else {
+          this.state[property] = numericLabel(value);
         }
       }
     }

--- a/src/state/miot-properties.ts
+++ b/src/state/miot-properties.ts
@@ -1,0 +1,80 @@
+import { getModelProfile } from "./model-profiles";
+import type { HassEntity } from "../types";
+
+export const MIOT_FAN_PROPERTY_ATTRIBUTES = {
+  horizontalSwing: ["fan.horizontal_swing"],
+  horizontalAngle: ["fan.horizontal_swing_included_angle", "horizontal_swing_included_angle-2-7"],
+  verticalSwing: ["fan.vertical_swing"],
+  verticalAngle: ["fan.vertical_swing_included_angle", "vertical_swing_included_angle-2-9"],
+} as const;
+
+export type MiotFanProperty = keyof typeof MIOT_FAN_PROPERTY_ATTRIBUTES;
+export type MiotFanProperties = Partial<Record<MiotFanProperty, string>>;
+
+const entityModel = (entity: HassEntity): unknown =>
+  entity.attributes["model"] ?? entity.attributes["model_name"] ?? entity.attributes["miot_model"];
+
+export const withMiotInfo = (entity: HassEntity | undefined, info: HassEntity | undefined): HassEntity | undefined => {
+  if (
+    !entity ||
+    !info ||
+    info.state === "unavailable" ||
+    info.attributes["available"] === false ||
+    typeof info.attributes["button.info"] !== "string"
+  ) {
+    return entity;
+  }
+
+  const primaryModel = entityModel(entity);
+  const infoModel = entityModel(info);
+  if (primaryModel !== undefined && primaryModel !== infoModel) {
+    return entity;
+  }
+
+  const attributes = { ...entity.attributes };
+  if (primaryModel === undefined && typeof infoModel === "string") {
+    attributes["model"] = infoModel;
+  }
+
+  // Info carries device diagnostics too; only copy the fan fields we use.
+  for (const keys of Object.values(MIOT_FAN_PROPERTY_ATTRIBUTES)) {
+    for (const key of keys) {
+      if (!Object.prototype.hasOwnProperty.call(attributes, key) && info.attributes[key] !== undefined) {
+        attributes[key] = info.attributes[key];
+      }
+    }
+  }
+
+  return { ...entity, attributes };
+};
+
+export const resolveMiotFanProperties = (entity: HassEntity | undefined): MiotFanProperties => {
+  if (!entity) {
+    return {};
+  }
+
+  const model = entityModel(entity);
+  const profile = getModelProfile(typeof model === "string" ? model : undefined);
+  // P76's spec confirms these properties are writable; other models need their own evidence.
+  if (profile.model !== "xiaomi.fan.p76") {
+    return {};
+  }
+
+  const properties: MiotFanProperties = {};
+  for (const property of Object.keys(MIOT_FAN_PROPERTY_ATTRIBUTES) as MiotFanProperty[]) {
+    const field = MIOT_FAN_PROPERTY_ATTRIBUTES[property].find((key) => {
+      const value = entity.attributes[key];
+      if (property === "horizontalSwing" || property === "verticalSwing") {
+        return typeof value === "boolean";
+      }
+
+      const angles = property === "horizontalAngle" ? profile.horizontalAngles : profile.verticalAngles;
+      return typeof value === "number" && angles.includes(value);
+    });
+    if (field !== undefined) {
+      properties[property] = field;
+    }
+  }
+
+  return properties;
+};

--- a/src/state/normalize-state.ts
+++ b/src/state/normalize-state.ts
@@ -49,7 +49,7 @@ export const numericLabel = (value: unknown): number | undefined => {
   return match ? Number(match[1]) : undefined;
 };
 
-const booleanValue = (value: unknown): boolean | undefined => {
+export const booleanValue = (value: unknown): boolean | undefined => {
   if (typeof value === "boolean") {
     return value;
   }

--- a/src/state/normalize-state.ts
+++ b/src/state/normalize-state.ts
@@ -1,5 +1,6 @@
 import type { FanMode, HassEntity, NormalizedFanState } from "../types";
 import { getModelProfile, resolveSpeedLevels, speedLevelForPercentage } from "./model-profiles";
+import { MIOT_FAN_PROPERTY_ATTRIBUTES } from "./miot-properties";
 import type { TimerUnit } from "../types";
 
 export const parseTimerUnit = (value: unknown): TimerUnit => {
@@ -208,15 +209,27 @@ export const normalizeFanState = (entityId: string, entity?: HassEntity): Normal
       "horizontal_oscillating",
       "horizontal_oscillation",
       "swing_mode",
+      ...MIOT_FAN_PROPERTY_ATTRIBUTES.horizontalSwing,
     ]),
     horizontalAngle: firstAngle(attributes, [
       "horizontal_swing_angle",
       "horizontal_angle",
       "swing_mode_angle",
       "angle",
+      ...MIOT_FAN_PROPERTY_ATTRIBUTES.horizontalAngle,
     ]),
-    verticalSwing: firstBoolean(attributes, ["vertical_swing", "vertical_oscillate", "vertical_oscillation"]),
-    verticalAngle: firstAngle(attributes, ["vertical_swing_angle", "vertical_oscillation_angle", "vertical_angle"]),
+    verticalSwing: firstBoolean(attributes, [
+      "vertical_swing",
+      "vertical_oscillate",
+      "vertical_oscillation",
+      ...MIOT_FAN_PROPERTY_ATTRIBUTES.verticalSwing,
+    ]),
+    verticalAngle: firstAngle(attributes, [
+      "vertical_swing_angle",
+      "vertical_oscillation_angle",
+      "vertical_angle",
+      ...MIOT_FAN_PROPERTY_ATTRIBUTES.verticalAngle,
+    ]),
     timerMinutes: timerMinutes(attributes, profile.timerUnit),
     childLock: booleanValue(attributes["child_lock"]),
     led: ledState(attributes),

--- a/src/state/related-entities.ts
+++ b/src/state/related-entities.ts
@@ -3,6 +3,7 @@ import type { HassLike, RelatedEntities } from "../types";
 interface RegistryEntity {
   entity_id: string;
   device_id?: string;
+  platform?: string;
   name?: string;
   original_name?: string;
   device_class?: string;
@@ -10,6 +11,7 @@ interface RegistryEntity {
 }
 
 const suffixes: Record<keyof RelatedEntities, string[]> = {
+  miotInfo: [],
   sleepMode: ["_sleep_mode"],
   horizontalSwing: ["_oscillating", "_oscillate", "_horizontal_swing", "_horizontal_oscillation", "_swing_mode"],
   verticalSwing: ["_vertical_swing", "_vertical_oscillate", "_vertical_oscillating", "_vertical_oscillation"],
@@ -107,6 +109,14 @@ export const resolveRelatedEntities = async (
     const entries = registry.filter((entry) => entry.device_id === primary.device_id);
 
     const related: RelatedEntities = {};
+    if (primary.platform === "xiaomi_miot") {
+      related.miotInfo = entries.find(
+        (entry) =>
+          entry.platform === "xiaomi_miot" &&
+          entry.entity_id.startsWith("button.") &&
+          typeof hass.states[entry.entity_id]?.attributes["button.info"] === "string",
+      )?.entity_id;
+    }
     const numeric = ["number", "input_number"];
     const angle = [...numeric, "select"];
     const boolean = ["switch", "input_boolean"];

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export interface HassEntity {
 }
 
 export interface RelatedEntities {
+  miotInfo?: string;
   sleepMode?: string;
   horizontalSwing?: string;
   verticalSwing?: string;

--- a/tests/component/card.test.ts
+++ b/tests/component/card.test.ts
@@ -6,6 +6,7 @@ import { XiaomiFanCard } from "../../src/card";
 import { getModelProfile } from "../../src/state/model-profiles";
 import type { FanCardConfig, HassEntity, HassLike } from "../../src/types";
 import { standardPowerContracts } from "../fixtures/integration-contracts";
+import { xiaomiMiotP76InfoHass } from "../fixtures/xiaomi-miot-p76";
 
 const services = {
   xiaomi_miio_fan: {
@@ -148,6 +149,53 @@ afterEach(() => {
 });
 
 describe("XiaomiFanCard", () => {
+  it("renders and updates Xiaomi Miot angle controls from same-device Info properties", async () => {
+    const hass = xiaomiMiotP76InfoHass();
+    const callService = vi.fn();
+    hass.callService = callService;
+    const card = new XiaomiFanCard();
+    card.hass = hass as unknown as HomeAssistant;
+    card.setConfig({
+      ...baseConfig,
+      entity: "fan.xiaomi_p76",
+      integration: "xiaomi_miot",
+      related_entities: {},
+      controls: { ...baseConfig.controls, show_vertical_swing: true, show_nudge: false, show_timer: false },
+    });
+    document.body.append(card);
+    await settle(card);
+
+    const selects = card.shadowRoot!.querySelectorAll<HTMLSelectElement>(".angle-controls select");
+    expect(selects).toHaveLength(2);
+    expect([...selects].map((select) => select.value)).toEqual(["30", "30"]);
+    expect(card.shadowRoot!.querySelector(".chip-row")).not.toBeNull();
+
+    selects[1]!.value = "60";
+    selects[1]!.dispatchEvent(new Event("change", { bubbles: true }));
+    await settle(card);
+
+    expect(callService).toHaveBeenCalledWith("xiaomi_miot", "set_property", {
+      entity_id: "fan.xiaomi_p76",
+      field: "vertical_swing_included_angle-2-9",
+      value: 60,
+    });
+
+    const info = hass.states["button.xiaomi_p76_info"]!;
+    card.hass = {
+      ...hass,
+      states: {
+        ...hass.states,
+        "button.xiaomi_p76_info": {
+          ...info,
+          attributes: { ...info.attributes, "vertical_swing_included_angle-2-9": 90 },
+        },
+      },
+    } as unknown as HomeAssistant;
+    await settle(card);
+
+    expect(card.shadowRoot!.querySelectorAll<HTMLSelectElement>(".angle-controls select")[1]!.value).toBe("90");
+  });
+
   it("renders active timer and angle selectors in separate columns", async () => {
     const { card } = await renderCard(baseConfig);
     const root = card.shadowRoot;

--- a/tests/fixtures/xiaomi-miot-p76.ts
+++ b/tests/fixtures/xiaomi-miot-p76.ts
@@ -66,3 +66,52 @@ export const xiaomiMiotP76Hass = (): HassLike => ({
     return {} as T;
   },
 });
+
+export const xiaomiMiotP76InfoHass = (): HassLike => ({
+  states: {
+    "fan.xiaomi_p76": {
+      state: "on",
+      attributes: {
+        friendly_name: "Test fan",
+        supported_features: 11,
+        percentage: 100,
+        percentage_step: 1,
+        preset_mode: "Straight Wind",
+        preset_modes: ["Straight Wind", "Natural Wind"],
+        oscillating: true,
+      },
+    },
+    "button.xiaomi_p76_info": {
+      state: "unknown",
+      attributes: {
+        "button.info": "Xiaomi Fan",
+        model: "xiaomi.fan.p76",
+        miot_type: "urn:miot-spec-v2:device:fan:0000A005:xiaomi-p76:1:0000D062",
+        available: true,
+        "fan.on": true,
+        "fan.horizontal_swing": true,
+        "horizontal_swing_included_angle-2-7": 30,
+        "fan.vertical_swing": true,
+        "vertical_swing_included_angle-2-9": 30,
+      },
+    },
+  },
+  callService: () => undefined,
+  callWS: async <T>(message: Record<string, unknown>) => {
+    if (message.type === "config/entity_registry/list") {
+      return [
+        { entity_id: "fan.xiaomi_p76", device_id: "device-miot-p76", platform: "xiaomi_miot" },
+        { entity_id: "button.xiaomi_p76_info", device_id: "device-miot-p76", platform: "xiaomi_miot" },
+      ] as T;
+    }
+
+    if (message.type === "get_services") {
+      return {
+        fan: services.fan,
+        xiaomi_miot: { set_property: {} },
+      } as T;
+    }
+
+    return {} as T;
+  },
+});

--- a/tests/fixtures/xiaomi-miot-p76.ts
+++ b/tests/fixtures/xiaomi-miot-p76.ts
@@ -73,7 +73,8 @@ export const xiaomiMiotP76InfoHass = (): HassLike => ({
       state: "on",
       attributes: {
         friendly_name: "Test fan",
-        supported_features: 11,
+        // SET_SPEED | OSCILLATE | PRESET_MODE | TURN_OFF | TURN_ON
+        supported_features: 59,
         percentage: 100,
         percentage_step: 1,
         preset_mode: "Straight Wind",

--- a/tests/unit/integration-regressions.test.ts
+++ b/tests/unit/integration-regressions.test.ts
@@ -5,9 +5,25 @@ import { loadServiceAvailability } from "../../src/services/service-dispatcher";
 import { resolveRelatedEntities } from "../../src/state/related-entities";
 import type { HassLike } from "../../src/types";
 import { airPurifier4ProHass } from "../fixtures/air-purifier-4-pro";
-import { xiaomiMiotP76Hass } from "../fixtures/xiaomi-miot-p76";
+import { xiaomiMiotP76Hass, xiaomiMiotP76InfoHass } from "../fixtures/xiaomi-miot-p76";
 
 describe("integration regression fixtures", () => {
+  it.each([
+    ["MIoT", xiaomiMiotP76Hass],
+    ["MIoT Info", xiaomiMiotP76InfoHass],
+  ] as const)("keeps %s fixture defaults usable", async (_name, createHass) => {
+    const hass = createHass();
+    const originalStates = structuredClone(hass.states);
+
+    await expect(hass.callWS!({ type: "unknown" })).resolves.toEqual({});
+
+    const services = await loadServiceAvailability(hass);
+    const adapter = createFanAdapter(hass, "fan.xiaomi_p76", services, "xiaomi_miot");
+    await adapter.togglePower();
+
+    expect(hass.states).toEqual(originalStates);
+  });
+
   it("discovers MIoT P76 controls and dispatches standard and select services", async () => {
     const hass = xiaomiMiotP76Hass();
     const services = await loadServiceAvailability(hass);

--- a/tests/unit/miot-properties.test.ts
+++ b/tests/unit/miot-properties.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { resolveMiotFanProperties, withMiotInfo } from "../../src/state/miot-properties";
+import { xiaomiMiotP76InfoHass } from "../fixtures/xiaomi-miot-p76";
+
+describe("Xiaomi Miot property metadata", () => {
+  it("copies only model and supported property attributes without changing the original entity", () => {
+    const hass = xiaomiMiotP76InfoHass();
+    const fan = hass.states["fan.xiaomi_p76"]!;
+    const info = hass.states["button.xiaomi_p76_info"]!;
+    const original = structuredClone(fan);
+    info.attributes["unrelated_metadata"] = "ignore";
+    const merged = withMiotInfo(fan, info)!;
+
+    expect(merged).not.toBe(fan);
+    expect(merged.state).toBe(fan.state);
+    expect(merged.attributes).toMatchObject({
+      model: "xiaomi.fan.p76",
+      friendly_name: "Test fan",
+      "fan.vertical_swing": true,
+      "vertical_swing_included_angle-2-9": 30,
+    });
+    expect(merged.attributes["button.info"]).toBeUndefined();
+    expect(merged.attributes["unrelated_metadata"]).toBeUndefined();
+    expect(fan).toEqual(original);
+  });
+
+  it("keeps live primary properties authoritative over Info values", () => {
+    const hass = xiaomiMiotP76InfoHass();
+    const fan = hass.states["fan.xiaomi_p76"]!;
+    fan.attributes["fan.vertical_swing"] = false;
+    fan.attributes["vertical_swing_included_angle-2-9"] = 100;
+    const merged = withMiotInfo(fan, hass.states["button.xiaomi_p76_info"])!;
+
+    expect(merged.attributes["fan.vertical_swing"]).toBe(false);
+    expect(merged.attributes["vertical_swing_included_angle-2-9"]).toBe(100);
+  });
+
+  it("does not recreate a missing primary entity from Info metadata", () => {
+    const hass = xiaomiMiotP76InfoHass();
+    expect(withMiotInfo(undefined, hass.states["button.xiaomi_p76_info"])).toBeUndefined();
+    expect(withMiotInfo(hass.states["fan.xiaomi_p76"], undefined)).toBe(hass.states["fan.xiaomi_p76"]);
+  });
+
+  it.each(["unavailable", "offline", "missing-marker", "different-model"])("ignores %s Info metadata", (condition) => {
+    const hass = xiaomiMiotP76InfoHass();
+    const fan = hass.states["fan.xiaomi_p76"]!;
+    const info = hass.states["button.xiaomi_p76_info"]!;
+    if (condition === "unavailable") info.state = "unavailable";
+    if (condition === "offline") info.attributes["available"] = false;
+    if (condition === "missing-marker") delete info.attributes["button.info"];
+    if (condition === "different-model") fan.attributes["model"] = "xiaomi.fan.p70";
+
+    expect(withMiotInfo(fan, info)).toBe(fan);
+  });
+
+  it("resolves the exact exposed P76 property names", () => {
+    const hass = xiaomiMiotP76InfoHass();
+    expect(resolveMiotFanProperties(hass.states["button.xiaomi_p76_info"])).toEqual({
+      horizontalSwing: "fan.horizontal_swing",
+      horizontalAngle: "horizontal_swing_included_angle-2-7",
+      verticalSwing: "fan.vertical_swing",
+      verticalAngle: "vertical_swing_included_angle-2-9",
+    });
+  });
+
+  it.each(["model", "model_name", "miot_model"])("recognizes a primary %s model attribute", (key) => {
+    expect(
+      resolveMiotFanProperties({
+        state: "on",
+        attributes: { [key]: "xiaomi.fan.p76", "fan.vertical_swing": false },
+      }),
+    ).toEqual({ verticalSwing: "fan.vertical_swing" });
+  });
+
+  it("does not extrapolate writable properties to other models", () => {
+    expect(resolveMiotFanProperties(undefined)).toEqual({});
+    expect(
+      resolveMiotFanProperties({
+        state: "on",
+        attributes: { model: "xiaomi.fan.p70", "fan.vertical_swing": true },
+      }),
+    ).toEqual({});
+  });
+
+  it.each([undefined, null, "30", "unknown", 0, 45, Number.NaN])(
+    "does not expose invalid angle property value %s",
+    (value) => {
+      expect(
+        resolveMiotFanProperties({
+          state: "on",
+          attributes: { model: "xiaomi.fan.p76", "vertical_swing_included_angle-2-9": value },
+        }),
+      ).toEqual({});
+    },
+  );
+
+  it.each([undefined, null, "false", 0])("does not expose invalid swing property value %s", (value) => {
+    expect(
+      resolveMiotFanProperties({
+        state: "on",
+        attributes: { model: "xiaomi.fan.p76", "fan.vertical_swing": value },
+      }),
+    ).toEqual({});
+  });
+});

--- a/tests/unit/normalize-state.test.ts
+++ b/tests/unit/normalize-state.test.ts
@@ -114,4 +114,34 @@ describe("normalizeFanState", () => {
 
     expect(state.timerMinutes).toBe(2);
   });
+
+  it("reads Xiaomi Miot swing properties and ID-suffixed angle attributes", () => {
+    const state = normalizeFanState("fan.miot", {
+      state: "on",
+      attributes: {
+        "fan.horizontal_swing": false,
+        "fan.vertical_swing": true,
+        "horizontal_swing_included_angle-2-7": 60,
+        "vertical_swing_included_angle-2-9": 100,
+      },
+    });
+
+    expect(state.horizontalSwing).toBe(false);
+    expect(state.verticalSwing).toBe(true);
+    expect(state.horizontalAngle).toBe(60);
+    expect(state.verticalAngle).toBe(100);
+  });
+
+  it("reads fully qualified Xiaomi Miot angle names", () => {
+    const state = normalizeFanState("fan.miot", {
+      state: "on",
+      attributes: {
+        "fan.horizontal_swing_included_angle": 90,
+        "fan.vertical_swing_included_angle": 30,
+      },
+    });
+
+    expect(state.horizontalAngle).toBe(90);
+    expect(state.verticalAngle).toBe(30);
+  });
 });

--- a/tests/unit/related-entities.test.ts
+++ b/tests/unit/related-entities.test.ts
@@ -1,8 +1,47 @@
 import { describe, expect, it } from "vitest";
 import { resolveRelatedEntities } from "../../src/state/related-entities";
 import type { HassLike } from "../../src/types";
+import { xiaomiMiotP76InfoHass } from "../fixtures/xiaomi-miot-p76";
 
 describe("resolveRelatedEntities", () => {
+  it("discovers Xiaomi Miot Info by its marker, not its translated entity name", async () => {
+    const hass = xiaomiMiotP76InfoHass();
+    hass.states["button.localized_information"] = hass.states["button.xiaomi_p76_info"]!;
+    hass.callWS = async <T>() =>
+      [
+        { entity_id: "fan.xiaomi_p76", device_id: "device-1", platform: "xiaomi_miot" },
+        { entity_id: "button.localized_information", device_id: "device-1", platform: "xiaomi_miot" },
+      ] as T;
+
+    await expect(resolveRelatedEntities(hass, "fan.xiaomi_p76")).resolves.toMatchObject({
+      miotInfo: "button.localized_information",
+      verticalSwing: undefined,
+      horizontalAngle: undefined,
+      verticalAngle: undefined,
+    });
+  });
+
+  it.each([
+    ["xiaomi_miio", "xiaomi_miot"],
+    ["xiaomi_miot", "xiaomi_miio"],
+  ])("does not share Info between %s and %s integrations", async (primaryPlatform, infoPlatform) => {
+    const hass = xiaomiMiotP76InfoHass();
+    hass.callWS = async <T>() =>
+      [
+        { entity_id: "fan.xiaomi_p76", device_id: "device-1", platform: primaryPlatform },
+        { entity_id: "button.xiaomi_p76_info", device_id: "device-1", platform: infoPlatform },
+      ] as T;
+
+    expect((await resolveRelatedEntities(hass, "fan.xiaomi_p76"))?.miotInfo).toBeUndefined();
+  });
+
+  it("does not assume every same-device button is an Info entity", async () => {
+    const hass = xiaomiMiotP76InfoHass();
+    delete hass.states["button.xiaomi_p76_info"]!.attributes["button.info"];
+
+    expect((await resolveRelatedEntities(hass, "fan.xiaomi_p76"))?.miotInfo).toBeUndefined();
+  });
+
   it("discovers optional controls across supported entity domains", async () => {
     const hass: HassLike = {
       states: {

--- a/tests/unit/xiaomi-miot-properties.test.ts
+++ b/tests/unit/xiaomi-miot-properties.test.ts
@@ -215,26 +215,70 @@ describe("Xiaomi Miot P76 property controls", () => {
     ]);
   });
 
-  it("uses live Info values when unavailable related entities cannot provide a control", async () => {
-    const { hass, services, related, callService } = await createAdapter();
-    hass.states["select.p76_vertical_angle"] = { state: "unavailable", attributes: { options: ["30", "60"] } };
-    hass.states["switch.p76_vertical_swing"] = { state: "unavailable", attributes: {} };
-    const adapter = createFanAdapter(hass, "fan.xiaomi_p76", services, "xiaomi_miot", {
-      ...related,
-      verticalAngle: "select.p76_vertical_angle",
-      verticalSwing: "switch.p76_vertical_swing",
-    });
+  it.each([
+    ["horizontal", false, 120, 90],
+    ["vertical", true, 100, 60],
+  ] as const)(
+    "uses live Info values when %s related controls are unavailable",
+    async (axis, swing, currentAngle, targetAngle) => {
+      const hass = xiaomiMiotP76InfoHass();
+      const info = hass.states["button.xiaomi_p76_info"]!;
+      const angleField =
+        axis === "horizontal" ? "horizontal_swing_included_angle-2-7" : "vertical_swing_included_angle-2-9";
+      const swingField = axis === "horizontal" ? "fan.horizontal_swing" : "fan.vertical_swing";
+      const angleCapability = axis === "horizontal" ? "horizontalAngle" : "verticalAngle";
+      const anglesCapability = axis === "horizontal" ? "horizontalAngles" : "verticalAngles";
+      const swingCapability = axis === "horizontal" ? "horizontalSwing" : "verticalSwing";
+      const angleState = axis === "horizontal" ? "select.p76_horizontal_angle" : "select.p76_vertical_angle";
+      const swingState = axis === "horizontal" ? "switch.p76_horizontal_swing" : "switch.p76_vertical_swing";
 
-    expect(adapter.capabilities.verticalAngle).toBe(true);
-    expect(adapter.state.verticalAngle).toBe(30);
-    expect(adapter.state.verticalSwing).toBe(true);
-    await adapter.setVerticalAngle(60);
-    expect(callService).toHaveBeenCalledWith("xiaomi_miot", "set_property", {
-      entity_id: "fan.xiaomi_p76",
-      field: "vertical_swing_included_angle-2-9",
-      value: 60,
-    });
-  });
+      info.attributes[swingField] = swing;
+      info.attributes[angleField] = currentAngle;
+      if (axis === "horizontal") {
+        hass.states["fan.xiaomi_p76"]!.attributes["supported_features"] = 1;
+        delete hass.states["fan.xiaomi_p76"]!.attributes["oscillating"];
+      }
+
+      const { services, related, callService } = await createAdapter(hass);
+      hass.states[angleState] = {
+        state: "unavailable",
+        attributes: { options: ["30", "60", "90", "100", "120"] },
+      };
+      hass.states[swingState] = { state: "unavailable", attributes: {} };
+      const adapter = createFanAdapter(
+        hass,
+        "fan.xiaomi_p76",
+        services,
+        "xiaomi_miot",
+        axis === "horizontal"
+          ? { ...related, horizontalAngle: angleState, horizontalSwing: swingState }
+          : { ...related, verticalAngle: angleState, verticalSwing: swingState },
+      );
+
+      expect(adapter.state[axis === "horizontal" ? "horizontalAngle" : "verticalAngle"]).toBe(currentAngle);
+      expect(adapter.state[axis === "horizontal" ? "horizontalSwing" : "verticalSwing"]).toBe(swing);
+      expect(adapter.capabilities[angleCapability]).toBe(true);
+      expect(adapter.capabilities[swingCapability]).toBe(true);
+      expect(adapter.capabilities[anglesCapability]).toEqual(
+        axis === "horizontal" ? [30, 60, 90, 120] : [30, 60, 90, 100],
+      );
+
+      if (axis === "horizontal") {
+        await adapter.setHorizontalAngle(targetAngle);
+      } else {
+        await adapter.setVerticalAngle(targetAngle);
+      }
+
+      expect(callService.mock.calls).toEqual(
+        swing
+          ? [["xiaomi_miot", "set_property", { entity_id: "fan.xiaomi_p76", field: angleField, value: targetAngle }]]
+          : [
+              ["xiaomi_miot", "set_property", { entity_id: "fan.xiaomi_p76", field: swingField, value: true }],
+              ["xiaomi_miot", "set_property", { entity_id: "fan.xiaomi_p76", field: angleField, value: targetAngle }],
+            ],
+      );
+    },
+  );
 
   it("rejects unsupported angles before starting either swing axis", async () => {
     const hass = xiaomiMiotP76InfoHass();

--- a/tests/unit/xiaomi-miot-properties.test.ts
+++ b/tests/unit/xiaomi-miot-properties.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, it, vi } from "vitest";
+import { createFanAdapter } from "../../src/adapters";
+import { loadServiceAvailability, ServiceDispatcher } from "../../src/services/service-dispatcher";
+import { resolveRelatedEntities } from "../../src/state/related-entities";
+import type { FanCardConfig, HassLike } from "../../src/types";
+import { xiaomiMiotP76InfoHass } from "../fixtures/xiaomi-miot-p76";
+
+const createAdapter = async (
+  hass = xiaomiMiotP76InfoHass(),
+  integration: FanCardConfig["integration"] = "xiaomi_miot",
+) => {
+  const services = await loadServiceAvailability(hass);
+  const related = await resolveRelatedEntities(hass, "fan.xiaomi_p76");
+  const callService = vi.fn();
+  hass.callService = callService;
+  const adapter = createFanAdapter(hass, "fan.xiaomi_p76", services, integration, related);
+  return { adapter, callService, hass, services, related };
+};
+
+describe("Xiaomi Miot P76 property controls", () => {
+  it("reads swing and angle properties from the same-device Info entity", async () => {
+    const { adapter } = await createAdapter();
+
+    expect(adapter.state.model).toBe("xiaomi.fan.p76");
+    expect(adapter.state.horizontalSwing).toBe(true);
+    expect(adapter.state.verticalSwing).toBe(true);
+    expect(adapter.state.horizontalAngle).toBe(30);
+    expect(adapter.state.verticalAngle).toBe(30);
+    expect(adapter.state.available).toBe(true);
+    expect(adapter.capabilities.verticalSwing).toBe(true);
+    expect(adapter.capabilities.horizontalAngle).toBe(true);
+    expect(adapter.capabilities.verticalAngle).toBe(true);
+    expect(adapter.capabilities.horizontalAngles).toEqual([30, 60, 90, 120]);
+    expect(adapter.capabilities.verticalAngles).toEqual([30, 60, 90, 100]);
+    expect(adapter.capabilities.directionNudge).toBe(false);
+  });
+
+  it("writes the exact exposed field names through Xiaomi Miot", async () => {
+    const { adapter, callService } = await createAdapter();
+
+    await adapter.setVerticalSwing(false);
+    await adapter.setHorizontalAngle(90);
+    await adapter.setVerticalAngle(60);
+
+    expect(callService.mock.calls).toEqual([
+      ["xiaomi_miot", "set_property", { entity_id: "fan.xiaomi_p76", field: "fan.vertical_swing", value: false }],
+      [
+        "xiaomi_miot",
+        "set_property",
+        { entity_id: "fan.xiaomi_p76", field: "horizontal_swing_included_angle-2-7", value: 90 },
+      ],
+      [
+        "xiaomi_miot",
+        "set_property",
+        { entity_id: "fan.xiaomi_p76", field: "vertical_swing_included_angle-2-9", value: 60 },
+      ],
+    ]);
+  });
+
+  it("enables vertical swing before setting its angle", async () => {
+    const hass = xiaomiMiotP76InfoHass();
+    hass.states["button.xiaomi_p76_info"]!.attributes["fan.vertical_swing"] = false;
+    const { adapter, callService } = await createAdapter(hass);
+
+    await adapter.setVerticalAngle(100);
+
+    expect(callService.mock.calls).toEqual([
+      ["xiaomi_miot", "set_property", { entity_id: "fan.xiaomi_p76", field: "fan.vertical_swing", value: true }],
+      [
+        "xiaomi_miot",
+        "set_property",
+        { entity_id: "fan.xiaomi_p76", field: "vertical_swing_included_angle-2-9", value: 100 },
+      ],
+    ]);
+  });
+
+  it("keeps property controls hidden without the registered property service", async () => {
+    const hass = xiaomiMiotP76InfoHass();
+    const { related } = await createAdapter(hass);
+    const adapter = createFanAdapter(
+      hass,
+      "fan.xiaomi_p76",
+      { loaded: true, names: new Set(["fan.oscillate"]) },
+      "xiaomi_miot",
+      related,
+    );
+
+    expect(adapter.capabilities.verticalSwing).toBe(false);
+    expect(adapter.capabilities.horizontalAngle).toBe(false);
+    expect(adapter.capabilities.verticalAngle).toBe(false);
+    await expect(adapter.setVerticalSwing(true)).rejects.toThrow("writable Xiaomi Miot");
+    await expect(adapter.setHorizontalAngle(90)).rejects.toThrow("writable Xiaomi Miot");
+    await expect(adapter.setVerticalAngle(60)).rejects.toThrow("writable Xiaomi Miot");
+    expect(hass.callService).not.toHaveBeenCalled();
+  });
+
+  it("does not use an Info entity from another device", async () => {
+    const hass = xiaomiMiotP76InfoHass();
+    const callWS = hass.callWS!;
+    hass.callWS = async <T>(message: Record<string, unknown>) => {
+      if (message.type === "config/entity_registry/list") {
+        return [
+          { entity_id: "fan.xiaomi_p76", device_id: "device-miot-p76", platform: "xiaomi_miot" },
+          { entity_id: "button.xiaomi_p76_info", device_id: "other-device", platform: "xiaomi_miot" },
+        ] as T;
+      }
+      return callWS<T>(message);
+    };
+    const { adapter } = await createAdapter(hass);
+
+    expect(adapter.capabilities.verticalSwing).toBe(false);
+    expect(adapter.capabilities.horizontalAngle).toBe(false);
+    expect(adapter.capabilities.verticalAngle).toBe(false);
+  });
+
+  it("does not invent properties from the model alone", async () => {
+    const hass: HassLike = xiaomiMiotP76InfoHass();
+    hass.states["button.xiaomi_p76_info"]!.attributes = {
+      "button.info": "Xiaomi Fan",
+      model: "xiaomi.fan.p76",
+      miot_type: "urn:miot-spec-v2:device:fan:0000A005:xiaomi-p76:1:0000D062",
+    };
+    const { adapter } = await createAdapter(hass);
+
+    expect(adapter.capabilities.verticalSwing).toBe(false);
+    expect(adapter.capabilities.horizontalAngle).toBe(false);
+    expect(adapter.capabilities.verticalAngle).toBe(false);
+  });
+
+  it.each(["auto", "standard", "xiaomi_miio", "xiaomi_miio_fan"] as const)(
+    "does not opt %s into Xiaomi Miot property services",
+    async (integration) => {
+      const { adapter } = await createAdapter(xiaomiMiotP76InfoHass(), integration);
+      expect(adapter.capabilities.verticalSwing).toBe(false);
+      expect(adapter.capabilities.horizontalAngle).toBe(false);
+      expect(adapter.capabilities.verticalAngle).toBe(false);
+    },
+  );
+
+  it("accepts fully qualified angle properties on the primary fan without Info discovery", async () => {
+    const hass = xiaomiMiotP76InfoHass();
+    hass.states["fan.xiaomi_p76"]!.attributes = {
+      model: "xiaomi.fan.p76",
+      supported_features: 1,
+      "fan.horizontal_swing": true,
+      "fan.vertical_swing": true,
+      "fan.horizontal_swing_included_angle": 30,
+      "fan.vertical_swing_included_angle": 60,
+    };
+    const { services, callService } = await createAdapter(hass);
+    const adapter = createFanAdapter(hass, "fan.xiaomi_p76", services, "xiaomi_miot");
+
+    expect(adapter.state.horizontalAngle).toBe(30);
+    expect(adapter.state.verticalAngle).toBe(60);
+    await adapter.setHorizontalSwing(false);
+    await adapter.setHorizontalAngle(120);
+    await adapter.setVerticalAngle(90);
+
+    expect(callService.mock.calls).toEqual([
+      ["xiaomi_miot", "set_property", { entity_id: "fan.xiaomi_p76", field: "fan.horizontal_swing", value: false }],
+      [
+        "xiaomi_miot",
+        "set_property",
+        { entity_id: "fan.xiaomi_p76", field: "fan.horizontal_swing_included_angle", value: 120 },
+      ],
+      [
+        "xiaomi_miot",
+        "set_property",
+        { entity_id: "fan.xiaomi_p76", field: "fan.vertical_swing_included_angle", value: 90 },
+      ],
+    ]);
+  });
+
+  it("preserves standard fan oscillation when enabling a horizontal angle", async () => {
+    const hass = xiaomiMiotP76InfoHass();
+    hass.states["fan.xiaomi_p76"]!.attributes["oscillating"] = false;
+    const { adapter, callService } = await createAdapter(hass);
+
+    await adapter.setHorizontalAngle(90);
+
+    expect(callService.mock.calls).toEqual([
+      ["fan", "oscillate", { entity_id: "fan.xiaomi_p76", oscillating: true }],
+      [
+        "xiaomi_miot",
+        "set_property",
+        { entity_id: "fan.xiaomi_p76", field: "horizontal_swing_included_angle-2-7", value: 90 },
+      ],
+    ]);
+  });
+
+  it("prefers actionable related entities and their angle options over raw properties", async () => {
+    const { hass, services, related, callService } = await createAdapter();
+    hass.states["select.p76_horizontal_angle"] = { state: "45°", attributes: { options: ["15°", "45°"] } };
+    hass.states["select.p76_vertical_angle"] = { state: "75°", attributes: { options: ["45°", "75°"] } };
+    hass.states["switch.p76_vertical_swing"] = { state: "off", attributes: {} };
+    const adapter = createFanAdapter(hass, "fan.xiaomi_p76", services, "xiaomi_miot", {
+      ...related,
+      horizontalAngle: "select.p76_horizontal_angle",
+      verticalAngle: "select.p76_vertical_angle",
+      verticalSwing: "switch.p76_vertical_swing",
+    });
+
+    expect(adapter.state.horizontalAngle).toBe(45);
+    expect(adapter.state.verticalAngle).toBe(75);
+    expect(adapter.state.verticalSwing).toBe(false);
+    expect(adapter.capabilities.horizontalAngles).toEqual([15, 45]);
+    expect(adapter.capabilities.verticalAngles).toEqual([45, 75]);
+    await adapter.setHorizontalAngle(15);
+    await adapter.setVerticalAngle(45);
+
+    expect(callService.mock.calls).toEqual([
+      ["select", "select_option", { entity_id: "select.p76_horizontal_angle", option: "15°" }],
+      ["switch", "turn_on", { entity_id: "switch.p76_vertical_swing" }],
+      ["select", "select_option", { entity_id: "select.p76_vertical_angle", option: "45°" }],
+    ]);
+  });
+
+  it("uses live Info values when unavailable related entities cannot provide a control", async () => {
+    const { hass, services, related, callService } = await createAdapter();
+    hass.states["select.p76_vertical_angle"] = { state: "unavailable", attributes: { options: ["30", "60"] } };
+    hass.states["switch.p76_vertical_swing"] = { state: "unavailable", attributes: {} };
+    const adapter = createFanAdapter(hass, "fan.xiaomi_p76", services, "xiaomi_miot", {
+      ...related,
+      verticalAngle: "select.p76_vertical_angle",
+      verticalSwing: "switch.p76_vertical_swing",
+    });
+
+    expect(adapter.capabilities.verticalAngle).toBe(true);
+    expect(adapter.state.verticalAngle).toBe(30);
+    expect(adapter.state.verticalSwing).toBe(true);
+    await adapter.setVerticalAngle(60);
+    expect(callService).toHaveBeenCalledWith("xiaomi_miot", "set_property", {
+      entity_id: "fan.xiaomi_p76",
+      field: "vertical_swing_included_angle-2-9",
+      value: 60,
+    });
+  });
+
+  it("rejects unsupported angles before starting either swing axis", async () => {
+    const hass = xiaomiMiotP76InfoHass();
+    hass.states["fan.xiaomi_p76"]!.attributes["oscillating"] = false;
+    hass.states["button.xiaomi_p76_info"]!.attributes["fan.vertical_swing"] = false;
+    const { adapter, callService } = await createAdapter(hass);
+
+    await expect(adapter.setHorizontalAngle(140)).rejects.toThrow("Unsupported Xiaomi Miot horizontal angle");
+    await expect(adapter.setVerticalAngle(45)).rejects.toThrow("Unsupported Xiaomi Miot vertical angle");
+    await expect(adapter.setVerticalAngle(Number.NaN)).rejects.toThrow("Unsupported Xiaomi Miot vertical angle");
+    expect(callService).not.toHaveBeenCalled();
+  });
+
+  it.each(["unavailable", "unknown"])("does not enable property writes for an %s primary fan", async (state) => {
+    const hass = xiaomiMiotP76InfoHass();
+    hass.states["fan.xiaomi_p76"]!.state = state;
+    const { adapter, callService } = await createAdapter(hass);
+
+    expect(adapter.capabilities.verticalAngle).toBe(false);
+    await expect(adapter.setVerticalAngle(60)).rejects.toThrow("writable Xiaomi Miot");
+    expect(callService).not.toHaveBeenCalled();
+  });
+
+  it("does not call property services until service discovery succeeds", async () => {
+    const { hass, related, callService } = await createAdapter();
+    const adapter = createFanAdapter(
+      hass,
+      "fan.xiaomi_p76",
+      { loaded: false, names: new Set(["xiaomi_miot.set_property"]) },
+      "xiaomi_miot",
+      related,
+    );
+
+    expect(adapter.capabilities.verticalAngle).toBe(false);
+    await expect(adapter.setVerticalAngle(60)).rejects.toThrow("writable Xiaomi Miot");
+    expect(callService).not.toHaveBeenCalled();
+  });
+
+  it("propagates service failures without calling another integration", async () => {
+    const { adapter, callService } = await createAdapter();
+    callService.mockRejectedValue(new Error("Write failed"));
+
+    await expect(adapter.setVerticalSwing(false)).rejects.toThrow("Write failed");
+    expect(callService).toHaveBeenCalledTimes(1);
+    expect(callService.mock.calls[0]?.[0]).toBe("xiaomi_miot");
+  });
+
+  it("reports a property service rejected by the dispatcher without falling back", async () => {
+    const { adapter, callService } = await createAdapter();
+    const dispatch = vi.spyOn(ServiceDispatcher.prototype, "custom").mockResolvedValue(false);
+    try {
+      await expect(adapter.setVerticalSwing(false)).rejects.toThrow("xiaomi_miot.set_property is unavailable");
+      expect(callService).not.toHaveBeenCalled();
+    } finally {
+      dispatch.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Description

Fix missing vertical oscillation and horizontal/vertical angle controls for `xiaomi.fan.p76` using Xiaomi Miot when properties are exposed on the same-device Info button instead of separate switch/select entities.

- Add an explicit `xiaomi_miot` adapter with a verified P76 property fallback through `xiaomi_miot.set_property`.
- Discover the Info entity using its registry device, integration, and `button.info` marker. Copy only the model and supported fan properties, not diagnostic data.
- Normalize MIoT swing attributes and both fully qualified and ID-suffixed angle field names. Write the exact exposed field name, without guessing property IDs.
- Require the registered service and valid boolean/allowed angle values. Keep actionable related entities and standard horizontal oscillation ahead of the fallback.
- Preserve all other integration modes and visibility-only controls. This fallback requires `integration: xiaomi_miot` and does not activate in `auto` or `standard`.
- Add redacted fixtures, state/adapter/discovery regressions, and a component test covering control rendering, dispatch, and subsequent Info updates.
- Update README and compatibility/configuration guidance, and regenerate `dist/xiaomi-fan-card.js`.

The earlier regression fixture assumed dedicated select entities and missed this Info-only layout. The writable fields and angle ranges were checked against the public P76 MIoT specification and the Xiaomi Miot service implementation.

## Related issue

Community report of missing P76 controls with Xiaomi Miot. No linked GitHub issue.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] CI or maintenance

## Validation

- [x] `npm run validate` - formatting, ESLint, TypeScript, coverage, 187 tests, and production build passed.
- [x] `prs validate --strict` - passed.
- [x] Generated-bundle smoke test - custom-card registration, Info-only angle controls, and mocked Xiaomi Miot dispatch passed.
- [x] HACS manifest, bundle filename, resource URL, and release asset consistency checked.
- [x] `git diff --check` - passed.

No physical P76 or live Home Assistant device was controlled. HACS GitHub Actions will validate the PR in CI. Rollup reports a non-failing `this` rewrite warning in `@formatjs/intl-utils`.

## Checklist

- [x] Tests added or updated
- [x] Documentation updated
- [x] `dist/xiaomi-fan-card.js` regenerated
- [x] Generated agent files left unchanged; no PromptScript changes required
- [x] No secrets or private Home Assistant data included
- [x] Existing control UI reused; rendering and interaction covered by component tests rather than new screenshots
