### PR TITLE
docs: keep graphic styles caption on one loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,18 @@ in.
   </a>
 </div>
 
+<div align="center">
+  <a href="https://raw.githubusercontent.com/mrwogu/xiaomi-smart-fan-card/main/docs/media/animation-running-gust.webp">
+    <img src="https://raw.githubusercontent.com/mrwogu/xiaomi-smart-fan-card/main/docs/media/animation-running-gust.webp" alt="The gust arc circling the speed ring while the rotor spins, as a loop" height="360">
+  </a>
+</div>
+
+<div align="center">
+  <a href="https://raw.githubusercontent.com/mrwogu/xiaomi-smart-fan-card/main/docs/media/animation-oscillation-chevrons.webp">
+    <img src="https://raw.githubusercontent.com/mrwogu/xiaomi-smart-fan-card/main/docs/media/animation-oscillation-chevrons.webp" alt="Air chevrons shooting alternately left and right while the fan oscillates, as a loop" height="360">
+  </a>
+</div>
+
 ```yaml
 visual:
   running_animation: gust # rotor (default) | gust
@@ -142,18 +154,6 @@ The graphic styles, cycling on the production card:
 <div align="center">
   <a href="https://raw.githubusercontent.com/mrwogu/xiaomi-smart-fan-card/main/docs/media/graphic-styles.webp">
     <img src="https://raw.githubusercontent.com/mrwogu/xiaomi-smart-fan-card/main/docs/media/graphic-styles.webp" alt="The production card looping blades, prop, turbine, minimal, stream, drift, bars, and plume graphic styles at live speed" height="360">
-  </a>
-</div>
-
-<div align="center">
-  <a href="https://raw.githubusercontent.com/mrwogu/xiaomi-smart-fan-card/main/docs/media/animation-running-gust.webp">
-    <img src="https://raw.githubusercontent.com/mrwogu/xiaomi-smart-fan-card/main/docs/media/animation-running-gust.webp" alt="The gust arc circling the speed ring while the rotor spins, as a loop" height="360">
-  </a>
-</div>
-
-<div align="center">
-  <a href="https://raw.githubusercontent.com/mrwogu/xiaomi-smart-fan-card/main/docs/media/animation-oscillation-chevrons.webp">
-    <img src="https://raw.githubusercontent.com/mrwogu/xiaomi-smart-fan-card/main/docs/media/animation-oscillation-chevrons.webp" alt="Air chevrons shooting alternately left and right while the fan oscillates, as a loop" height="360">
   </a>
 </div>
 


### PR DESCRIPTION
## Why

After #65 merged, the README caption **The graphic styles, cycling on the production card:** had three images. Only `graphic-styles.webp` belongs there. The gust and chevron clips are leftover animation demos.

## Change

Move `animation-running-gust.webp` and `animation-oscillation-chevrons.webp` up next to `animation-styles-compare.webp`. The graphic styles caption keeps one loop.

## Test

- [x] README heading now has one image under graphic styles
- [x] Gust and chevron loops still appear in Optional animation styles